### PR TITLE
chore: handle sanity refractor dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,9 +81,5 @@
       "refractor": "3.6.0"
     }
   },
-  "resolutions": {
-    "refractor": "3.6.0",
-    "sanity/refractor": "3.6.0"
-  },
   "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67"
 }

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -138,5 +138,10 @@ export default defineConfig({
         },
       },
     ],
+    build: {
+      rollupOptions: {
+        external: ['sanity/refractor'],
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- remove invalid `sanity/refractor` resolution causing pnpm install failures
- mark `sanity/refractor` as an external in Vite build config

## Testing
- `pnpm install`
- `pnpm build` *(fails: Failed to fetch remote version)*

------
https://chatgpt.com/codex/tasks/task_e_68c48c2f5c28832cb7847dd0166e4318