### PR TITLE
Scope studio theme styles to Sanity layout

### DIFF
--- a/components/studio/CustomerDashboard.tsx
+++ b/components/studio/CustomerDashboard.tsx
@@ -797,30 +797,30 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
   const activeEmail = activeProfile?.email ?? activeSummary?.email ?? ''
 
   return (
-    <div ref={ref} className="flex h-full min-h-0 flex-col bg-slate-100">
+    <div ref={ref} className="studio-surface flex h-full min-h-0 flex-col rounded-3xl">
       <div className="flex-1 overflow-hidden px-6 py-6">
         <div className="mx-auto flex h-full max-w-7xl flex-col gap-6 lg:flex-row">
           <div className="flex flex-col gap-4 lg:w-[420px] xl:w-[460px]">
-            <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-              <div className="border-b border-slate-200 bg-white px-6 py-5">
+            <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-sm">
+              <div className="border-b border-[var(--studio-border)] bg-[var(--studio-surface-strong)] px-6 py-5">
                 <div className="flex flex-wrap items-start justify-between gap-4">
                   <div>
-                    <h1 className="text-xl font-semibold text-slate-900">Customers</h1>
-                    <p className="mt-1 text-sm text-slate-500">
+                    <h1 className="text-xl font-semibold text-[var(--studio-text)]">Customers</h1>
+                    <p className="mt-1 text-sm text-[var(--studio-muted)]">
                       {customerCount.toLocaleString()} customers · {customerCount > 0 ? '100% of your customer base' : 'No customers yet'}
                     </p>
                   </div>
                   <div className="flex flex-wrap items-center gap-2">
                     <button
                       type="button"
-                      className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-900"
+                      className="rounded-lg border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] px-4 py-2 text-sm font-medium text-[var(--studio-text)] shadow-sm transition hover:border-[var(--studio-border-strong)] hover:text-[var(--studio-text)]"
                       onClick={() => console.info('Export customers action not yet connected')}
                     >
                       Export
                     </button>
                     <button
                       type="button"
-                      className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-900"
+                      className="rounded-lg border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] px-4 py-2 text-sm font-medium text-[var(--studio-text)] shadow-sm transition hover:border-[var(--studio-border-strong)] hover:text-[var(--studio-text)]"
                       onClick={() => console.info('Import customers action not yet connected')}
                     >
                       Import
@@ -839,17 +839,17 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                 )}
               </div>
 
-              <div className="border-b border-slate-200 bg-slate-50 px-6 py-4">
+              <div className="border-b border-[var(--studio-border)] bg-[var(--studio-surface-soft)] px-6 py-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div className="relative flex-1 min-w-[220px]">
                     <input
                       type="search"
-                      className="w-full rounded-lg border border-slate-200 bg-white px-10 py-2 text-sm text-slate-700 shadow-inner outline-none transition placeholder:text-slate-400 focus:border-slate-300 focus:ring-2 focus:ring-slate-200"
+                      className="w-full rounded-lg border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] px-10 py-2 text-sm text-[var(--studio-text)] shadow-inner outline-none transition placeholder:text-[rgba(148,163,184,0.7)] focus:border-[var(--studio-border-strong)] focus:ring-2 focus:ring-slate-200"
                       placeholder="Search customers"
                       value={searchTerm}
                       onChange={(event) => setSearchTerm(event.target.value)}
                     />
-                    <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400">
+                    <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-[rgba(148,163,184,0.7)]">
                       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
                         <path
                           fillRule="evenodd"
@@ -862,7 +862,7 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                   <div className="flex flex-wrap items-center gap-2">
                     <button
                       type="button"
-                      className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-900"
+                      className="rounded-lg border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] px-3 py-2 text-sm font-medium text-[var(--studio-text)] shadow-sm transition hover:border-[var(--studio-border-strong)] hover:text-[var(--studio-text)]"
                       onClick={() => console.info('Filter menu not yet connected')}
                     >
                       Add filter
@@ -873,19 +873,22 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
 
               <div className="relative flex-1 min-h-0">
                 {loading && (
-                  <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/60">
+                  <div
+                    className="absolute inset-0 z-10 flex items-center justify-center"
+                    style={{background: 'var(--studio-backdrop)'}}
+                  >
                     <Spinner muted size={4} />
                   </div>
                 )}
                 <div className="h-full overflow-x-auto overflow-y-auto">
                   <table className="min-w-full table-fixed divide-y divide-slate-200">
-                    <thead className="sticky top-0 z-10 bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    <thead className="sticky top-0 z-10 bg-[var(--studio-surface-soft)] text-left text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
                       <tr>
                         <th className="w-12 px-6 py-3">
                           <label className="inline-flex items-center">
                             <input
                               type="checkbox"
-                              className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-400"
+                              className="h-4 w-4 rounded border-[var(--studio-border-strong)] text-[var(--studio-text)] focus:ring-slate-400"
                               checked={allSelected}
                               onChange={toggleSelectAll}
                               aria-label="Select all customers"
@@ -899,10 +902,10 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                         <th className="w-32 px-6 py-3 text-right">Amount spent</th>
                       </tr>
                     </thead>
-                    <tbody className="divide-y divide-slate-200 text-sm text-slate-700">
+                    <tbody className="divide-y divide-slate-200 text-sm text-[var(--studio-text)]">
                       {filteredCustomers.length === 0 && !loading ? (
                         <tr>
-                          <td colSpan={6} className="px-6 py-10 text-center text-sm text-slate-500">
+                          <td colSpan={6} className="px-6 py-10 text-center text-sm text-[var(--studio-muted)]">
                             No customers match your filters.
                           </td>
                         </tr>
@@ -914,7 +917,7 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                             <tr
                               key={customer._id}
                               className={`group cursor-pointer transition ${
-                                isActive ? 'bg-slate-100' : 'bg-white hover:bg-slate-50'
+                                isActive ? 'bg-[var(--studio-surface-soft)]' : 'bg-[var(--studio-surface-strong)] hover:bg-[var(--studio-surface-soft)]'
                               }`}
                               onClick={() => setActiveCustomerId(customer._id)}
                               onDoubleClick={() => handleRowNavigate(customer._id)}
@@ -924,7 +927,7 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                                 <label className="inline-flex items-center">
                                   <input
                                     type="checkbox"
-                                    className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-400"
+                                    className="h-4 w-4 rounded border-[var(--studio-border-strong)] text-[var(--studio-text)] focus:ring-slate-400"
                                     checked={isSelected}
                                     onChange={(event) => {
                                       event.stopPropagation()
@@ -935,17 +938,17 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                                 </label>
                               </td>
                               <td className="px-3 py-4">
-                                <div className="font-medium text-slate-900 group-hover:text-slate-900">{customer.displayName}</div>
-                                {customer.email && <div className="text-xs text-slate-500">{customer.email}</div>}
+                                <div className="font-medium text-[var(--studio-text)] group-hover:text-[var(--studio-text)]">{customer.displayName}</div>
+                                {customer.email && <div className="text-xs text-[var(--studio-muted)]">{customer.email}</div>}
                               </td>
                               <td className="px-3 py-4">
-                                <span className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-medium text-slate-600">
+                                <span className="inline-flex items-center rounded-full border border-[var(--studio-border)] bg-[var(--studio-surface-soft)] px-2.5 py-1 text-xs font-medium text-[var(--studio-muted)]">
                                   {getSubscriptionStatus(customer)}
                                 </span>
                               </td>
-                              <td className="px-3 py-4 text-slate-600">{customer.location}</td>
-                              <td className="px-3 py-4 text-slate-600">{formatOrders(customer.orderCount ?? 0)}</td>
-                              <td className="px-6 py-4 text-right font-medium text-slate-900">
+                              <td className="px-3 py-4 text-[var(--studio-muted)]">{customer.location}</td>
+                              <td className="px-3 py-4 text-[var(--studio-muted)]">{formatOrders(customer.orderCount ?? 0)}</td>
+                              <td className="px-6 py-4 text-right font-medium text-[var(--studio-text)]">
                                 {formatCurrency(customer.lifetimeSpend ?? 0)}
                               </td>
                             </tr>
@@ -959,34 +962,34 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
             </div>
           </div>
 
-          <div className="flex-1 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <div className="flex-1 overflow-hidden rounded-2xl border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-sm">
             {profileLoading ? (
               <div className="flex h-full items-center justify-center"><Spinner muted size={4} /></div>
             ) : activeCustomerId ? (
               <div className="flex h-full flex-col">
-                <header className="border-b border-slate-200 bg-white px-6 py-5">
+                <header className="border-b border-[var(--studio-border)] bg-[var(--studio-surface-strong)] px-6 py-5">
                   <div className="flex flex-wrap items-start justify-between gap-4">
                     <div className="flex min-w-0 flex-col gap-3">
-                      <nav className="flex items-center gap-2 text-sm text-slate-500">
-                        <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-sm font-semibold text-slate-600">C</span>
-                        <span className="text-slate-400">/</span>
-                        <span className="truncate font-medium text-slate-500">Customers</span>
-                        <span className="text-slate-400">/</span>
-                        <span className="truncate font-semibold text-slate-900" title={activeDisplayName}>
+                      <nav className="flex items-center gap-2 text-sm text-[var(--studio-muted)]">
+                        <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-[var(--studio-surface-soft)] text-sm font-semibold text-[var(--studio-muted)]">C</span>
+                        <span className="text-[rgba(148,163,184,0.7)]">/</span>
+                        <span className="truncate font-medium text-[var(--studio-muted)]">Customers</span>
+                        <span className="text-[rgba(148,163,184,0.7)]">/</span>
+                        <span className="truncate font-semibold text-[var(--studio-text)]" title={activeDisplayName}>
                           {activeDisplayName}
                         </span>
                       </nav>
                       <div className="min-w-0">
-                        <h2 className="truncate text-2xl font-semibold text-slate-900" title={activeDisplayName}>
+                        <h2 className="truncate text-2xl font-semibold text-[var(--studio-text)]" title={activeDisplayName}>
                           {activeDisplayName}
                         </h2>
-                        {activeEmail && <p className="truncate text-sm text-slate-500">{activeEmail}</p>}
+                        {activeEmail && <p className="truncate text-sm text-[var(--studio-muted)]">{activeEmail}</p>}
                       </div>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
                       <button
                         type="button"
-                        className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-900"
+                        className="inline-flex items-center gap-2 rounded-lg border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] px-4 py-2 text-sm font-medium text-[var(--studio-text)] shadow-sm transition hover:border-[var(--studio-border-strong)] hover:text-[var(--studio-text)]"
                         onClick={handleOpenInStudio}
                       >
                         More actions
@@ -994,13 +997,13 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                           <path d="M6 6.75a.75.75 0 111.5 0A.75.75 0 016 6.75zM9.25 6.75a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM13.5 6.75a.75.75 0 111.5 0 .75.75 0 01-1.5 0z" />
                         </svg>
                       </button>
-                      <div className="flex items-center overflow-hidden rounded-lg border border-slate-200">
+                      <div className="flex items-center overflow-hidden rounded-lg border border-[var(--studio-border)]">
                         <button
                           type="button"
                           onClick={goToPrevious}
                           disabled={!canGoPrevious}
-                          className={`flex h-9 w-10 items-center justify-center text-slate-600 transition ${
-                            canGoPrevious ? 'hover:bg-slate-100' : 'cursor-not-allowed opacity-40'
+                          className={`flex h-9 w-10 items-center justify-center text-[var(--studio-muted)] transition ${
+                            canGoPrevious ? 'hover:bg-[var(--studio-surface-soft)]' : 'cursor-not-allowed opacity-40'
                           }`}
                           aria-label="Previous customer"
                         >
@@ -1013,8 +1016,8 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                           type="button"
                           onClick={goToNext}
                           disabled={!canGoNext}
-                          className={`flex h-9 w-10 items-center justify-center text-slate-600 transition ${
-                            canGoNext ? 'hover:bg-slate-100' : 'cursor-not-allowed opacity-40'
+                          className={`flex h-9 w-10 items-center justify-center text-[var(--studio-muted)] transition ${
+                            canGoNext ? 'hover:bg-[var(--studio-surface-soft)]' : 'cursor-not-allowed opacity-40'
                           }`}
                           aria-label="Next customer"
                         >
@@ -1030,17 +1033,21 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                   )}
                 </header>
 
-                <div className="flex-1 overflow-auto bg-slate-50">
+                <div className="flex-1 overflow-auto" style={{background: 'var(--studio-surface-overlay)'}}>
                   <div className="flex flex-col gap-6 px-6 py-6">
-                    <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+                    <section className="overflow-hidden rounded-xl border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-sm">
                       <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-stretch sm:justify-between">
                         <div className="flex flex-1 flex-wrap gap-4">
                           {metrics.map((metric) => (
-                            <div key={metric.label} className="flex min-w-[160px] flex-1 flex-col rounded-lg border border-slate-200 bg-slate-50/60 p-4">
-                              <span className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                            <div
+                              key={metric.label}
+                              className="flex min-w-[160px] flex-1 flex-col rounded-lg border border-[var(--studio-border)] p-4"
+                              style={{background: 'var(--studio-surface-overlay)'}}
+                            >
+                              <span className="text-xs font-medium uppercase tracking-wide text-[var(--studio-muted)]">
                                 {metric.label}
                               </span>
-                              <span className="mt-2 text-lg font-semibold text-slate-900">{metric.value}</span>
+                              <span className="mt-2 text-lg font-semibold text-[var(--studio-text)]">{metric.value}</span>
                             </div>
                           ))}
                         </div>
@@ -1049,13 +1056,13 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
 
                     <div className="grid gap-6 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
                       <div className="flex flex-col gap-6">
-                        <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-                          <div className="border-b border-slate-200 px-6 py-4">
+                        <section className="overflow-hidden rounded-xl border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-sm">
+                          <div className="border-b border-[var(--studio-border)] px-6 py-4">
                             <div className="flex flex-wrap items-center justify-between gap-4">
                               <div>
-                                <h3 className="text-lg font-semibold text-slate-900">Last order placed</h3>
+                                <h3 className="text-lg font-semibold text-[var(--studio-text)]">Last order placed</h3>
                                 {latestOrderDate && (
-                                  <p className="text-sm text-slate-500">
+                                  <p className="text-sm text-[var(--studio-muted)]">
                                     {format(latestOrderDate, "MMMM d, yyyy 'at' h:mm a")}
                                   </p>
                                 )}
@@ -1063,7 +1070,7 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                               <div className="flex flex-wrap items-center gap-2">
                                 <button
                                   type="button"
-                                  className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-900"
+                                  className="rounded-lg border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] px-3 py-2 text-xs font-medium text-[var(--studio-text)] shadow-sm transition hover:border-[var(--studio-border-strong)] hover:text-[var(--studio-text)]"
                                   onClick={handleOpenInStudio}
                                 >
                                   View all orders
@@ -1083,9 +1090,9 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                               <div className="flex flex-col gap-4">
                                 <div className="flex flex-wrap items-center gap-3">
                                   {latestOrder.orderNumber ? (
-                                    <span className="text-base font-semibold text-slate-900">#{latestOrder.orderNumber}</span>
+                                    <span className="text-base font-semibold text-[var(--studio-text)]">#{latestOrder.orderNumber}</span>
                                   ) : (
-                                    <span className="text-base font-semibold text-slate-900">Order</span>
+                                    <span className="text-base font-semibold text-[var(--studio-text)]">Order</span>
                                   )}
                                   {latestOrder.status && (
                                     <span className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-700">
@@ -1093,49 +1100,49 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                                     </span>
                                   )}
                                   {latestOrderDate && (
-                                    <span className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-medium text-slate-600">
+                                    <span className="inline-flex items-center rounded-full border border-[var(--studio-border)] bg-[var(--studio-surface-soft)] px-2.5 py-1 text-xs font-medium text-[var(--studio-muted)]">
                                       {formatDistanceToNow(latestOrderDate, {addSuffix: true})}
                                     </span>
                                   )}
                                 </div>
-                                <div className="flex flex-wrap items-baseline justify-between gap-4 text-slate-700">
+                                <div className="flex flex-wrap items-baseline justify-between gap-4 text-[var(--studio-text)]">
                                   <div>
-                                    <p className="text-sm text-slate-500">Order total</p>
-                                    <p className="text-xl font-semibold text-slate-900">
+                                    <p className="text-sm text-[var(--studio-muted)]">Order total</p>
+                                    <p className="text-xl font-semibold text-[var(--studio-text)]">
                                       {formatCurrency(latestOrder.total ?? 0)}
                                     </p>
                                   </div>
                                 </div>
                               </div>
                             ) : (
-                              <p className="text-sm text-slate-500">This customer has not placed any orders yet.</p>
+                              <p className="text-sm text-[var(--studio-muted)]">This customer has not placed any orders yet.</p>
                             )}
                           </div>
                         </section>
 
-                        <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-                          <div className="border-b border-slate-200 px-6 py-4">
-                            <h3 className="text-lg font-semibold text-slate-900">Timeline</h3>
+                        <section className="overflow-hidden rounded-xl border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-sm">
+                          <div className="border-b border-[var(--studio-border)] px-6 py-4">
+                            <h3 className="text-lg font-semibold text-[var(--studio-text)]">Timeline</h3>
                           </div>
                           <div className="px-6 py-5">
                             {timelineSections.length === 0 ? (
-                              <p className="text-sm text-slate-500">Order activity will appear here once this customer places an order.</p>
+                              <p className="text-sm text-[var(--studio-muted)]">Order activity will appear here once this customer places an order.</p>
                             ) : (
                               <div className="space-y-6">
                                 {timelineSections.map((section) => (
                                   <div key={section.dateLabel}>
-                                    <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                    <h4 className="text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
                                       {section.dateLabel}
                                     </h4>
-                                    <ul className="mt-3 space-y-4 border-l border-slate-200 pl-5">
+                                    <ul className="mt-3 space-y-4 border-l border-[var(--studio-border)] pl-5">
                                       {section.entries.map((entry) => (
                                         <li key={entry.id} className="relative">
                                           <span className="absolute -left-[29px] mt-1 h-2.5 w-2.5 rounded-full bg-slate-400" aria-hidden="true" />
                                           <div className="flex flex-col gap-1">
-                                            <p className="text-sm font-medium text-slate-900">{entry.title}</p>
-                                            <p className="text-sm text-slate-500">{entry.description}</p>
+                                            <p className="text-sm font-medium text-[var(--studio-text)]">{entry.title}</p>
+                                            <p className="text-sm text-[var(--studio-muted)]">{entry.description}</p>
                                             {entry.timeLabel && (
-                                              <p className="text-xs text-slate-400">{entry.timeLabel}</p>
+                                              <p className="text-xs text-[rgba(148,163,184,0.7)]">{entry.timeLabel}</p>
                                             )}
                                           </div>
                                         </li>
@@ -1150,14 +1157,14 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                       </div>
 
                       <div className="flex flex-col gap-6">
-                        <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-                          <div className="border-b border-slate-200 px-6 py-4">
+                        <section className="overflow-hidden rounded-xl border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-sm">
+                          <div className="border-b border-[var(--studio-border)] px-6 py-4">
                             <div className="flex items-center justify-between">
-                              <h3 className="text-lg font-semibold text-slate-900">Customer</h3>
+                              <h3 className="text-lg font-semibold text-[var(--studio-text)]">Customer</h3>
                               <button
                                 type="button"
                                 onClick={handleOpenInStudio}
-                                className="rounded-md p-1.5 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700"
+                                className="rounded-md p-1.5 text-[var(--studio-muted)] transition hover:bg-[var(--studio-surface-soft)] hover:text-[var(--studio-text)]"
                                 aria-label="Open customer document"
                               >
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
@@ -1166,15 +1173,15 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                               </button>
                             </div>
                           </div>
-                          <div className="space-y-6 px-6 py-5 text-sm text-slate-700">
+                          <div className="space-y-6 px-6 py-5 text-sm text-[var(--studio-text)]">
                             <div className="space-y-2">
-                              <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Contact information</h4>
+                              <h4 className="text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">Contact information</h4>
                               <div className="flex flex-wrap items-center gap-2">
                                 {activeEmail ? (
                                   <button
                                     type="button"
                                     onClick={() => handleCopyToClipboard(activeEmail)}
-                                    className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-900"
+                                    className="inline-flex items-center gap-2 rounded-lg border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] px-3 py-2 text-sm font-medium text-[var(--studio-text)] shadow-sm transition hover:border-[var(--studio-border-strong)] hover:text-[var(--studio-text)]"
                                   >
                                     {activeEmail}
                                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
@@ -1183,31 +1190,31 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                                     </svg>
                                   </button>
                                 ) : (
-                                  <span className="text-slate-500">No email on file</span>
+                                  <span className="text-[var(--studio-muted)]">No email on file</span>
                                 )}
                               </div>
                               {activeProfile?.phone && (
-                                <div className="text-slate-600">{activeProfile.phone}</div>
+                                <div className="text-[var(--studio-muted)]">{activeProfile.phone}</div>
                               )}
                             </div>
 
                             <div className="space-y-2">
-                              <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Default address</h4>
+                              <h4 className="text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">Default address</h4>
                               {shippingLines.length > 0 ? (
-                                <address className="not-italic leading-relaxed text-slate-700">
+                                <address className="not-italic leading-relaxed text-[var(--studio-text)]">
                                   {shippingLines.map((line) => (
                                     <div key={line}>{line}</div>
                                   ))}
                                 </address>
                               ) : (
-                                <p className="text-slate-500">No shipping address stored.</p>
+                                <p className="text-[var(--studio-muted)]">No shipping address stored.</p>
                               )}
                             </div>
 
                             {billingLines.length > 0 && (
                               <div className="space-y-2">
-                                <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Billing address</h4>
-                                <address className="not-italic leading-relaxed text-slate-700">
+                                <h4 className="text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">Billing address</h4>
+                                <address className="not-italic leading-relaxed text-[var(--studio-text)]">
                                   {billingLines.map((line) => (
                                     <div key={line}>{line}</div>
                                   ))}
@@ -1217,21 +1224,21 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                           </div>
                         </section>
 
-                        <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-                          <div className="border-b border-slate-200 px-6 py-4">
-                            <h3 className="text-lg font-semibold text-slate-900">Marketing</h3>
+                        <section className="overflow-hidden rounded-xl border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-sm">
+                          <div className="border-b border-[var(--studio-border)] px-6 py-4">
+                            <h3 className="text-lg font-semibold text-[var(--studio-text)]">Marketing</h3>
                           </div>
                           <div className="space-y-3 px-6 py-5 text-sm">
                             {marketingStatuses.map((status) => (
-                              <div key={status.label} className="flex items-center gap-2 text-slate-700">
+                              <div key={status.label} className="flex items-center gap-2 text-[var(--studio-text)]">
                                 <span
                                   className={`h-2.5 w-2.5 rounded-full ${
                                     status.subscribed ? 'bg-emerald-500' : 'bg-slate-300'
                                   }`}
                                   aria-hidden="true"
                                 />
-                                <span className="font-medium text-slate-900">{status.label}</span>
-                                <span className="text-slate-500">
+                                <span className="font-medium text-[var(--studio-text)]">{status.label}</span>
+                                <span className="text-[var(--studio-muted)]">
                                   {status.subscribed ? 'Subscribed' : 'Not subscribed'}
                                 </span>
                               </div>
@@ -1239,58 +1246,58 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                           </div>
                         </section>
 
-                        <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-                          <div className="border-b border-slate-200 px-6 py-4">
-                            <h3 className="text-lg font-semibold text-slate-900">Payment method</h3>
+                        <section className="overflow-hidden rounded-xl border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-sm">
+                          <div className="border-b border-[var(--studio-border)] px-6 py-4">
+                            <h3 className="text-lg font-semibold text-[var(--studio-text)]">Payment method</h3>
                           </div>
                           <div className="px-6 py-5 text-sm">
                             {paymentMethods.length > 0 ? (
-                              <ul className="space-y-3 text-slate-700">
+                              <ul className="space-y-3 text-[var(--studio-text)]">
                                 {paymentMethods.slice(0, 3).map((method) => (
                                   <li key={method.key} className="flex items-center justify-between gap-3">
                                     <div>
-                                      <div className="font-medium text-slate-900">
+                                      <div className="font-medium text-[var(--studio-text)]">
                                         {method.last4 ? `${method.brand} •••• ${method.last4}` : method.brand}
                                       </div>
-                                      <div className="text-xs text-slate-500">
+                                      <div className="text-xs text-[var(--studio-muted)]">
                                         {method.lastUsed
                                           ? `Last used ${formatDistanceToNow(method.lastUsed, {addSuffix: true})}`
                                           : 'Usage date unavailable'}
                                       </div>
                                     </div>
-                                    <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-600">
+                                    <span className="rounded-full bg-[var(--studio-surface-soft)] px-2.5 py-1 text-xs font-medium text-[var(--studio-muted)]">
                                       {method.orderCount} {method.orderCount === 1 ? 'order' : 'orders'}
                                     </span>
                                   </li>
                                 ))}
                               </ul>
                             ) : (
-                              <p className="text-slate-500">We haven’t recorded any card payments for this customer yet.</p>
+                              <p className="text-[var(--studio-muted)]">We haven’t recorded any card payments for this customer yet.</p>
                             )}
                           </div>
                         </section>
 
-                        <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-                          <div className="border-b border-slate-200 px-6 py-4">
-                            <h3 className="text-lg font-semibold text-slate-900">Store credit</h3>
+                        <section className="overflow-hidden rounded-xl border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-sm">
+                          <div className="border-b border-[var(--studio-border)] px-6 py-4">
+                            <h3 className="text-lg font-semibold text-[var(--studio-text)]">Store credit</h3>
                           </div>
                           <div className="px-6 py-5 text-sm">
                             {storeCreditSummary.transactions.length > 0 ? (
-                              <div className="space-y-4 text-slate-700">
+                              <div className="space-y-4 text-[var(--studio-text)]">
                                 <div className="flex flex-wrap gap-6">
                                   <div>
-                                    <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                    <div className="text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
                                       Total redeemed
                                     </div>
-                                    <div className="text-base font-semibold text-slate-900">
+                                    <div className="text-base font-semibold text-[var(--studio-text)]">
                                       {formatCurrency(storeCreditSummary.totalRedeemed)}
                                     </div>
                                   </div>
                                   <div>
-                                    <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                    <div className="text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
                                       Transactions
                                     </div>
-                                    <div className="text-base font-semibold text-slate-900">
+                                    <div className="text-base font-semibold text-[var(--studio-text)]">
                                       {storeCreditSummary.transactions.length.toLocaleString()}
                                     </div>
                                   </div>
@@ -1299,14 +1306,14 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                                   {storeCreditSummary.transactions.slice(0, 5).map((transaction) => (
                                     <li key={transaction.id} className="flex flex-col gap-0.5">
                                       <div className="flex items-center justify-between text-sm">
-                                        <span className="font-medium text-slate-900">
+                                        <span className="font-medium text-[var(--studio-text)]">
                                           Redeemed {formatCurrency(transaction.amount)}
                                         </span>
                                         {transaction.orderNumber ? (
-                                          <span className="text-xs text-slate-500">Order {transaction.orderNumber}</span>
+                                          <span className="text-xs text-[var(--studio-muted)]">Order {transaction.orderNumber}</span>
                                         ) : null}
                                       </div>
-                                      <span className="text-xs text-slate-500">
+                                      <span className="text-xs text-[var(--studio-muted)]">
                                         {transaction.occurredAt
                                           ? `${format(transaction.occurredAt, 'MMM d, yyyy')} • ${formatDistanceToNow(transaction.occurredAt, {addSuffix: true})}`
                                           : 'Date unavailable'}
@@ -1315,25 +1322,25 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                                   ))}
                                 </ul>
                                 {storeCreditSummary.transactions.length > 5 ? (
-                                  <p className="text-xs text-slate-500">
+                                  <p className="text-xs text-[var(--studio-muted)]">
                                     Showing the 5 most recent credits out of {storeCreditSummary.transactions.length}.
                                   </p>
                                 ) : null}
                               </div>
                             ) : (
-                              <p className="text-slate-500">No store credit usage found in recent orders.</p>
+                              <p className="text-[var(--studio-muted)]">No store credit usage found in recent orders.</p>
                             )}
                           </div>
                         </section>
 
-                        <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-                          <div className="border-b border-slate-200 px-6 py-4">
+                        <section className="overflow-hidden rounded-xl border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-sm">
+                          <div className="border-b border-[var(--studio-border)] px-6 py-4">
                             <div className="flex items-center justify-between gap-2">
-                              <h3 className="text-lg font-semibold text-slate-900">Tags</h3>
+                              <h3 className="text-lg font-semibold text-[var(--studio-text)]">Tags</h3>
                               <button
                                 type="button"
                                 onClick={handleOpenInStudio}
-                                className="rounded-md p-1.5 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700"
+                                className="rounded-md p-1.5 text-[var(--studio-muted)] transition hover:bg-[var(--studio-surface-soft)] hover:text-[var(--studio-text)]"
                                 aria-label="Manage tags"
                               >
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
@@ -1342,23 +1349,23 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                               </button>
                             </div>
                           </div>
-                          <div className="flex flex-wrap gap-2 px-6 py-5 text-sm text-slate-700">
+                          <div className="flex flex-wrap gap-2 px-6 py-5 text-sm text-[var(--studio-text)]">
                             {roleTags.map((tag) => (
-                              <span key={tag} className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+                              <span key={tag} className="inline-flex items-center rounded-full bg-[var(--studio-surface-soft)] px-3 py-1 text-xs font-medium text-[var(--studio-muted)]">
                                 {tag}
                               </span>
                             ))}
                           </div>
                         </section>
 
-                        <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-                          <div className="border-b border-slate-200 px-6 py-4">
+                        <section className="overflow-hidden rounded-xl border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-sm">
+                          <div className="border-b border-[var(--studio-border)] px-6 py-4">
                             <div className="flex items-center justify-between">
-                              <h3 className="text-lg font-semibold text-slate-900">Notes</h3>
+                              <h3 className="text-lg font-semibold text-[var(--studio-text)]">Notes</h3>
                               <button
                                 type="button"
                                 onClick={handleOpenInStudio}
-                                className="rounded-md p-1.5 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700"
+                                className="rounded-md p-1.5 text-[var(--studio-muted)] transition hover:bg-[var(--studio-surface-soft)] hover:text-[var(--studio-text)]"
                                 aria-label="Edit notes"
                               >
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
@@ -1368,7 +1375,7 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                               </button>
                             </div>
                           </div>
-                          <div className="px-6 py-5 text-sm text-slate-600">No notes recorded for this customer.</div>
+                          <div className="px-6 py-5 text-sm text-[var(--studio-muted)]">No notes recorded for this customer.</div>
                         </section>
                       </div>
                     </div>
@@ -1376,7 +1383,7 @@ const CustomerDashboard = React.forwardRef<HTMLDivElement, Record<string, never>
                 </div>
               </div>
             ) : (
-              <div className="flex h-full items-center justify-center px-6 py-10 text-center text-sm text-slate-500">
+              <div className="flex h-full items-center justify-center px-6 py-10 text-center text-sm text-[var(--studio-muted)]">
                 Select a customer from the list to view their profile.
               </div>
             )}

--- a/components/studio/CustomersHub.tsx
+++ b/components/studio/CustomersHub.tsx
@@ -18,24 +18,24 @@ const CustomersHub = React.forwardRef<HTMLDivElement, Record<string, never>>((_p
   const activeMeta = tabs.find((tab) => tab.id === activeTab)
 
   return (
-    <div ref={ref} className="flex h-full min-h-0 flex-col bg-slate-100">
-      <header className="border-b border-slate-200 bg-white">
-        <div className="flex flex-col gap-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="text-lg font-semibold text-slate-900">Customer Hub</h1>
-            <p className="text-sm text-slate-500">{activeMeta?.description}</p>
+    <div ref={ref} className="studio-page">
+      <header className="studio-header">
+        <div className="studio-header__inner">
+          <div className="studio-header__titles">
+            <h1 className="studio-header__title">Customer Hub</h1>
+            <p className="studio-header__description">{activeMeta?.description}</p>
           </div>
-          <nav className="flex rounded-full border border-slate-200 bg-slate-100 p-1 text-sm font-medium text-slate-600 shadow-sm">
+          <nav className="studio-tablist" role="tablist" aria-label="Customer workspaces">
             {tabs.map((tab) => {
               const isActive = activeTab === tab.id
               return (
                 <button
                   key={tab.id}
                   type="button"
+                  role="tab"
+                  aria-selected={isActive}
                   onClick={() => setActiveTab(tab.id)}
-                  className={`rounded-full px-4 py-2 transition ${
-                    isActive ? 'bg-white text-slate-900 shadow-sm' : 'hover:text-slate-900'
-                  }`}
+                  className={`studio-tablist__button${isActive ? ' studio-tablist__button--active' : ''}`}
                 >
                   {tab.label}
                 </button>
@@ -45,7 +45,7 @@ const CustomersHub = React.forwardRef<HTMLDivElement, Record<string, never>>((_p
         </div>
       </header>
 
-      <main className="flex flex-1 min-h-0 flex-col">
+      <main className="studio-content">
         {activeTab === 'overview' ? (
           <CustomerDashboard />
         ) : activeTab === 'quotes' ? (

--- a/components/studio/FilterBulkAssignPane.tsx
+++ b/components/studio/FilterBulkAssignPane.tsx
@@ -7,30 +7,32 @@ const FilterBulkAssignPane = React.forwardRef<HTMLDivElement, Record<string, nev
   const normalized = tagInput.trim()
 
   return (
-    <div ref={ref} className="flex h-full min-h-0 flex-col bg-slate-100">
-      <div className="mx-auto w-full max-w-4xl px-6 py-6">
-        <header className="mb-6">
-          <h1 className="text-lg font-semibold text-slate-900">Bulk Assign Products to Filter</h1>
-          <p className="mt-2 text-sm text-slate-500">
-            Choose a filter tag and add it to multiple products at once.
-          </p>
-          <div className="mt-4 flex gap-3">
-            <input
-              type="text"
-              value={tagInput}
-              onChange={(event) => setTagInput(event.currentTarget.value)}
-              placeholder="Enter filter tag (e.g. wheels)"
-              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-            />
-          </div>
-        </header>
-        {normalized ? (
-          <FilterBulkAssign key={normalized} tag={normalized} />
-        ) : (
-          <div className="rounded-md border border-dashed border-slate-300 bg-white px-4 py-8 text-center text-sm text-slate-500">
-            Enter a filter tag above to begin assigning products.
-          </div>
-        )}
+    <div ref={ref} className="studio-page">
+      <div className="studio-content">
+        <div className="mx-auto w-full max-w-4xl">
+          <header className="mb-6">
+            <h1 className="text-lg font-semibold text-[var(--studio-text)]">Bulk Assign Products to Filter</h1>
+            <p className="mt-2 text-sm text-[var(--studio-muted)]">
+              Choose a filter tag and add it to multiple products at once.
+            </p>
+            <div className="mt-4 flex gap-3">
+              <input
+                type="text"
+                value={tagInput}
+                onChange={(event) => setTagInput(event.currentTarget.value)}
+                placeholder="Enter filter tag (e.g. wheels)"
+                className="w-full rounded-xl border border-[var(--studio-border-strong)] bg-[var(--studio-surface-strong)] px-4 py-2 text-sm text-[var(--studio-text)] shadow-sm transition focus:border-[var(--studio-accent)] focus:outline-none focus:ring-2 focus:ring-[rgba(37,99,235,0.25)]"
+              />
+            </div>
+          </header>
+          {normalized ? (
+            <FilterBulkAssign key={normalized} tag={normalized} />
+          ) : (
+            <div className="rounded-xl border border-dashed border-[var(--studio-border-strong)] bg-[var(--studio-surface-soft)] px-4 py-8 text-center text-sm text-[var(--studio-muted)]">
+              Enter a filter tag above to begin assigning products.
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/components/studio/FilterBulkRemovePane.tsx
+++ b/components/studio/FilterBulkRemovePane.tsx
@@ -7,30 +7,32 @@ const FilterBulkRemovePane = React.forwardRef<HTMLDivElement, Record<string, nev
   const normalized = tagInput.trim()
 
   return (
-    <div ref={ref} className="flex h-full min-h-0 flex-col bg-slate-100">
-      <div className="mx-auto w-full max-w-4xl px-6 py-6">
-        <header className="mb-6">
-          <h1 className="text-lg font-semibold text-slate-900">Bulk Remove Filter From Products</h1>
-          <p className="mt-2 text-sm text-slate-500">
-            Remove an existing filter tag from multiple products in one pass.
-          </p>
-          <div className="mt-4 flex gap-3">
-            <input
-              type="text"
-              value={tagInput}
-              onChange={(event) => setTagInput(event.currentTarget.value)}
-              placeholder="Enter filter tag (e.g. wheels)"
-              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-            />
-          </div>
-        </header>
-        {normalized ? (
-          <FilterBulkRemove key={normalized} tag={normalized} />
-        ) : (
-          <div className="rounded-md border border-dashed border-slate-300 bg-white px-4 py-8 text-center text-sm text-slate-500">
-            Enter a filter tag above to load matching products.
-          </div>
-        )}
+    <div ref={ref} className="studio-page">
+      <div className="studio-content">
+        <div className="mx-auto w-full max-w-4xl">
+          <header className="mb-6">
+            <h1 className="text-lg font-semibold text-[var(--studio-text)]">Bulk Remove Filter From Products</h1>
+            <p className="mt-2 text-sm text-[var(--studio-muted)]">
+              Remove an existing filter tag from multiple products in one pass.
+            </p>
+            <div className="mt-4 flex gap-3">
+              <input
+                type="text"
+                value={tagInput}
+                onChange={(event) => setTagInput(event.currentTarget.value)}
+                placeholder="Enter filter tag (e.g. wheels)"
+                className="w-full rounded-xl border border-[var(--studio-border-strong)] bg-[var(--studio-surface-strong)] px-4 py-2 text-sm text-[var(--studio-text)] shadow-sm transition focus:border-[var(--studio-accent)] focus:outline-none focus:ring-2 focus:ring-[rgba(37,99,235,0.25)]"
+              />
+            </div>
+          </header>
+          {normalized ? (
+            <FilterBulkRemove key={normalized} tag={normalized} />
+          ) : (
+            <div className="rounded-xl border border-dashed border-[var(--studio-border-strong)] bg-[var(--studio-surface-soft)] px-4 py-8 text-center text-sm text-[var(--studio-muted)]">
+              Enter a filter tag above to load matching products.
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/components/studio/FilterDeleteTagPane.tsx
+++ b/components/studio/FilterDeleteTagPane.tsx
@@ -7,31 +7,33 @@ const FilterDeleteTagPane = React.forwardRef<HTMLDivElement, Record<string, neve
   const normalized = tagInput.trim()
 
   return (
-    <div ref={ref} className="flex h-full min-h-0 flex-col bg-slate-100">
-      <div className="mx-auto w-full max-w-3xl px-6 py-6">
-        <header className="mb-6">
-          <h1 className="text-lg font-semibold text-slate-900">Delete Filter Tag Everywhere</h1>
-          <p className="mt-2 text-sm text-slate-500">
-            Remove a filter tag from every product. Once no products reference it, the tag
-            disappears from the storefront automatically.
-          </p>
-          <div className="mt-4 flex gap-3">
-            <input
-              type="text"
-              value={tagInput}
-              onChange={(event) => setTagInput(event.currentTarget.value)}
-              placeholder="Enter filter tag (e.g. wheels)"
-              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-            />
-          </div>
-        </header>
-        {normalized ? (
-          <FilterDeleteTag key={normalized} tag={normalized} />
-        ) : (
-          <div className="rounded-md border border-dashed border-slate-300 bg-white px-4 py-8 text-center text-sm text-slate-500">
-            Enter a filter tag above to see usage counts and delete options.
-          </div>
-        )}
+    <div ref={ref} className="studio-page">
+      <div className="studio-content">
+        <div className="mx-auto w-full max-w-3xl">
+          <header className="mb-6">
+            <h1 className="text-lg font-semibold text-[var(--studio-text)]">Delete Filter Tag Everywhere</h1>
+            <p className="mt-2 text-sm text-[var(--studio-muted)]">
+              Remove a filter tag from every product. Once no products reference it, the tag
+              disappears from the storefront automatically.
+            </p>
+            <div className="mt-4 flex gap-3">
+              <input
+                type="text"
+                value={tagInput}
+                onChange={(event) => setTagInput(event.currentTarget.value)}
+                placeholder="Enter filter tag (e.g. wheels)"
+                className="w-full rounded-xl border border-[var(--studio-border-strong)] bg-[var(--studio-surface-strong)] px-4 py-2 text-sm text-[var(--studio-text)] shadow-sm transition focus:border-[var(--studio-accent)] focus:outline-none focus:ring-2 focus:ring-[rgba(37,99,235,0.25)]"
+              />
+            </div>
+          </header>
+          {normalized ? (
+            <FilterDeleteTag key={normalized} tag={normalized} />
+          ) : (
+            <div className="rounded-xl border border-dashed border-[var(--studio-border-strong)] bg-[var(--studio-surface-soft)] px-4 py-8 text-center text-sm text-[var(--studio-muted)]">
+              Enter a filter tag above to see usage counts and delete options.
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/components/studio/FinancialDashboard.tsx
+++ b/components/studio/FinancialDashboard.tsx
@@ -294,7 +294,18 @@ const FinancialDashboard = React.forwardRef<HTMLDivElement, Record<string, never
   const handleCreateOrder = () => router.navigateIntent('create', {type: 'order'})
 
   return (
-    <Box ref={ref} padding={[3, 4, 5]} style={{background: '#f3f4f6', minHeight: '100%'}}>
+    <Box
+      ref={ref}
+      padding={[3, 4, 5]}
+      style={{
+        background: 'var(--studio-surface-overlay)',
+        minHeight: '100%',
+        borderRadius: '28px',
+        border: '1px solid var(--studio-border)',
+        boxShadow: 'var(--studio-shadow)',
+        backdropFilter: 'blur(18px)',
+      }}
+    >
       <Stack space={4}>
         <Flex align="center" justify="space-between" wrap="wrap" gap={3}>
           <Stack space={1}>
@@ -321,7 +332,7 @@ const FinancialDashboard = React.forwardRef<HTMLDivElement, Record<string, never
         </Flex>
 
         {loading ? (
-          <Card padding={6} radius={4} shadow={1} style={{background: '#ffffff'}}>
+          <Card padding={6} radius={4} shadow={1} style={{background: 'var(--studio-surface-strong)'}}>
             <Flex align="center" justify="center" direction="column" gap={3}>
               <Spinner muted />
               <Text muted>Preparing your financial insights…</Text>
@@ -390,7 +401,7 @@ function ProfitLossCard({summary, range}: {summary: Summary; range: RangePreset}
   const expenseShare = income + expenses > 0 ? (expenses / (income + expenses)) * 100 : 0
 
   return (
-    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: '#ffffff'}}>
+    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: 'var(--studio-surface-strong)'}}>
       <Stack space={4}>
         <Flex justify="space-between" align="center">
           <Stack space={1}>
@@ -441,7 +452,7 @@ function ExpensesCard({summary}: {summary: Summary}) {
   const categories = buildCategorySegments(summary.expenseCategories)
 
   return (
-    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: '#ffffff'}}>
+    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: 'var(--studio-surface-strong)'}}>
       <Stack space={4}>
         <Flex justify="space-between" align="center">
           <Stack space={1}>
@@ -487,7 +498,7 @@ function CashFlowCard({summary}: {summary: Summary}) {
   const moneyOut = summary.cashflowSeries.reduce((acc, point) => acc + point.expense, 0)
 
   return (
-    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: '#ffffff'}}>
+    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: 'var(--studio-surface-strong)'}}>
       <Stack space={4}>
         <Flex justify="space-between" align="center">
           <Stack space={1}>
@@ -521,7 +532,7 @@ function InvoicesCard({summary, range}: {summary: Summary; range: RangePreset}) 
   const paidPct = summary.paidLast30 + summary.unpaidLast30 > 0 ? (summary.paidLast30 / (summary.paidLast30 + summary.unpaidLast30)) * 100 : 0
 
   return (
-    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: '#ffffff'}}>
+    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: 'var(--studio-surface-strong)'}}>
       <Stack space={4}>
         <Flex justify="space-between" align="center">
           <Stack space={1}>
@@ -573,7 +584,7 @@ function SalesCard({summary}: {summary: Summary}) {
   const average = summary.salesSeries.length > 0 ? totalSales / summary.salesSeries.length : 0
 
   return (
-    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: '#ffffff'}}>
+    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: 'var(--studio-surface-strong)'}}>
       <Stack space={4}>
         <Stack space={1}>
           <Heading size={2}>Sales</Heading>
@@ -645,7 +656,7 @@ function IntegrationsCard({
   ]
 
   return (
-    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: '#ffffff'}}>
+    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: 'var(--studio-surface-strong)'}}>
       <Stack space={3}>
         <Heading size={2}>My integrations</Heading>
         <Stack space={2}>
@@ -657,7 +668,7 @@ function IntegrationsCard({
               shadow={0}
               tone="transparent"
               style={{
-                background: '#f8fafc',
+                background: 'var(--studio-surface-soft)',
                 cursor: 'pointer',
               }}
               role="button"
@@ -776,7 +787,7 @@ function OrdersIntegrationSection({
           <StatusList title="Payment status" items={paymentBreakdown} />
         </Flex>
 
-        <Card padding={4} radius={3} shadow={0} style={{background: '#f8fafc'}}>
+        <Card padding={4} radius={3} shadow={0} style={{background: 'var(--studio-surface-soft)'}}>
           <Stack space={3}>
             <Heading size={2}>Recent orders</Heading>
             <Stack space={2}>
@@ -820,7 +831,7 @@ function PayoutsIntegrationSection({payouts, onBack}: {payouts: PayoutSummary | 
         description="Connect Stripe to track deposits, balances, and payout schedules."
         onBack={onBack}
       >
-        <Card padding={4} radius={3} shadow={0} style={{background: '#f8fafc'}}>
+        <Card padding={4} radius={3} shadow={0} style={{background: 'var(--studio-surface-soft)'}}>
           <Stack space={2}>
             <Text weight="semibold">No payout data available</Text>
             <Text size={1} muted>
@@ -854,7 +865,7 @@ function PayoutsIntegrationSection({payouts, onBack}: {payouts: PayoutSummary | 
           />
         </Flex>
 
-        <Card padding={4} radius={3} shadow={0} style={{background: '#f8fafc'}}>
+        <Card padding={4} radius={3} shadow={0} style={{background: 'var(--studio-surface-soft)'}}>
           <Stack space={3}>
             <Heading size={2}>Recent payouts</Heading>
             <Stack space={2}>
@@ -899,7 +910,7 @@ function AnalyticsIntegrationSection({
         description="Connect your analytics source to track traffic alongside revenue."
         onBack={onBack}
       >
-        <Card padding={4} radius={3} shadow={0} style={{background: '#f8fafc'}}>
+        <Card padding={4} radius={3} shadow={0} style={{background: 'var(--studio-surface-soft)'}}>
           <Stack space={2}>
             <Text weight="semibold">No analytics data available</Text>
             <Text size={1} muted>
@@ -929,7 +940,7 @@ function AnalyticsIntegrationSection({
         </Flex>
 
         {hasTrend ? (
-          <Card padding={4} radius={3} shadow={0} style={{background: '#f8fafc'}}>
+          <Card padding={4} radius={3} shadow={0} style={{background: 'var(--studio-surface-soft)'}}>
             <Stack space={3}>
               <Heading size={2}>Session trend</Heading>
               <LineChart
@@ -943,7 +954,7 @@ function AnalyticsIntegrationSection({
           </Card>
         ) : null}
 
-        <Card padding={4} radius={3} shadow={0} style={{background: '#f8fafc'}}>
+        <Card padding={4} radius={3} shadow={0} style={{background: 'var(--studio-surface-soft)'}}>
           <Stack space={3}>
             <Heading size={2}>Recent daily metrics</Heading>
             <Stack space={2}>
@@ -981,7 +992,7 @@ function IntegrationShell({
   children: React.ReactNode
 }) {
   return (
-    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: '#ffffff'}}>
+    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: 'var(--studio-surface-strong)'}}>
       <Stack space={4}>
         <Flex align="center" justify="space-between" wrap="wrap" gap={3}>
           <Stack space={1}>
@@ -1006,7 +1017,7 @@ function DetailStatCard({
   helper?: string
 }) {
   return (
-    <Card padding={4} radius={3} shadow={0} style={{background: '#f8fafc', flex: '1 1 220px'}}>
+    <Card padding={4} radius={3} shadow={0} style={{background: 'var(--studio-surface-soft)', flex: '1 1 220px'}}>
       <Stack space={1}>
         <Text size={1} muted>{label}</Text>
         <Text weight="semibold">{value}</Text>
@@ -1028,7 +1039,7 @@ function StatusList({
   items: Array<{label: string; count: number}>
 }) {
   return (
-    <Card padding={4} radius={3} shadow={0} style={{background: '#f8fafc', flex: '1 1 240px'}}>
+    <Card padding={4} radius={3} shadow={0} style={{background: 'var(--studio-surface-soft)', flex: '1 1 240px'}}>
       <Stack space={2}>
         <Heading size={2}>{title}</Heading>
         <Stack space={1}>
@@ -1081,7 +1092,7 @@ function AccountsReceivableCard({summary}: {summary: Summary}) {
   ]
 
   return (
-    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: '#ffffff'}}>
+    <Card padding={[4, 5]} radius={4} shadow={1} style={{background: 'var(--studio-surface-strong)'}}>
       <Stack space={4}>
         <Flex justify="space-between" align="center">
           <Heading size={2}>Accounts receivable</Heading>
@@ -1222,7 +1233,7 @@ function DonutChart({
           position: 'absolute',
           inset: thickness,
           borderRadius: '50%',
-          background: '#ffffff',
+          background: 'var(--studio-surface-strong)',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',

--- a/components/studio/InvoiceDashboard.tsx
+++ b/components/studio/InvoiceDashboard.tsx
@@ -447,22 +447,26 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
     if (invoice.isOverdue) return 'text-rose-600 bg-rose-50 border border-rose-100'
     if (invoice.status === 'paid') return 'text-emerald-600 bg-emerald-50 border border-emerald-100'
     if (invoice.status === 'refunded') return 'text-sky-600 bg-sky-50 border border-sky-100'
-    if (invoice.status === 'cancelled') return 'text-slate-500 bg-slate-100 border border-slate-200'
+    if (invoice.status === 'cancelled') return 'text-[var(--studio-muted)] bg-[var(--studio-surface-soft)] border border-[var(--studio-border)]'
     return 'text-amber-600 bg-amber-50 border border-amber-100'
   }
 
   return (
-    <div ref={ref} className="flex h-full min-h-0 flex-col bg-slate-100">
-      <div className="border-b border-slate-200 bg-white">
+    <div ref={ref} className="studio-surface flex h-full min-h-0 flex-col rounded-3xl">
+      <div
+        className="border-b border-[var(--studio-border)] backdrop-blur"
+        style={{background: 'var(--studio-surface-strong)'}}
+      >
         <div
-          className={`sticky top-0 z-20 flex flex-col gap-4 bg-white px-4 transition-all duration-200 sm:px-6 ${
+          className={`sticky top-0 z-20 flex flex-col gap-4 px-4 transition-all duration-200 backdrop-blur sm:px-6 ${
             compactHeader ? 'py-3 shadow-sm sm:flex-row sm:items-center sm:justify-between' : 'py-5 sm:flex-row sm:items-start sm:justify-between'
           }`}
+          style={{background: 'var(--studio-surface-strong)'}}
         >
           <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="min-w-0">
               <h1
-                className={`text-xs font-semibold uppercase tracking-wide text-slate-600 transition-all duration-200 ${
+                className={`text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)] transition-all duration-200 ${
                   compactHeader ? 'opacity-80' : ''
                 }`}
               >
@@ -488,9 +492,9 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
                   disabled={batchLoading}
                   aria-haspopup="menu"
                   aria-expanded={batchMenuOpen}
-                  className={`inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-300 px-3 py-1.5 text-xs font-medium shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 ${
-                    hasSelections ? 'text-slate-600 hover:bg-slate-100' : 'text-slate-400 hover:bg-white'
-                  } ${batchMenuOpen ? 'bg-slate-100' : ''} disabled:cursor-not-allowed disabled:opacity-60`}
+                  className={`inline-flex items-center justify-center whitespace-nowrap rounded-md border border-[var(--studio-border-strong)] px-3 py-1.5 text-xs font-medium shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 ${
+                    hasSelections ? 'text-[var(--studio-muted)] hover:bg-[var(--studio-surface-soft)]' : 'text-[rgba(148,163,184,0.7)] hover:bg-[var(--studio-surface-strong)]'
+                  } ${batchMenuOpen ? 'bg-[var(--studio-surface-soft)]' : ''} disabled:cursor-not-allowed disabled:opacity-60`}
                 >
                   {batchLoading ? 'Working…' : 'Batch actions'}
                 </button>
@@ -499,17 +503,17 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
                     ref={batchMenuRef}
                     role="menu"
                     aria-label="Batch actions"
-                    className="absolute right-0 top-full z-30 mt-2 w-44 overflow-hidden rounded-md border border-slate-200 bg-white shadow-lg"
+                    className="absolute right-0 top-full z-30 mt-2 w-44 overflow-hidden rounded-md border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-lg"
                   >
                     <button
                       type="button"
                       onClick={handleBatchMarkPaidClick}
                       role="menuitem"
                       disabled={!hasSelections || batchLoading}
-                      className="flex w-full items-center justify-between px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400"
+                      className="flex w-full items-center justify-between px-3 py-2 text-sm text-[var(--studio-text)] transition hover:bg-[var(--studio-surface-soft)] disabled:cursor-not-allowed disabled:text-[rgba(148,163,184,0.7)]"
                     >
                       <span>Mark selected paid</span>
-                      {hasSelections ? <span className="text-xs text-slate-400">{selectedIds.size}</span> : null}
+                      {hasSelections ? <span className="text-xs text-[rgba(148,163,184,0.7)]">{selectedIds.size}</span> : null}
                     </button>
                   </div>
                 ) : null}
@@ -519,7 +523,10 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
         </div>
       </div>
 
-      <div className="border-b border-slate-200 bg-white">
+      <div
+        className="border-b border-[var(--studio-border)]"
+        style={{background: 'var(--studio-surface-strong)'}}
+      >
         <div className="-mx-2 flex gap-3 overflow-x-auto px-4 pb-4 pt-4 sm:-mx-3 sm:px-6 lg:grid lg:grid-cols-5 lg:gap-3 lg:overflow-visible lg:px-6 lg:pb-6 lg:pt-6">
           <div className="min-w-[150px] flex-shrink-0 sm:min-w-[170px] lg:min-w-0 lg:flex-shrink">
             <SummaryCard title="Unpaid" subtitle="Last 12 months" amount={metrics.unpaidYear} />
@@ -539,7 +546,7 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
               subtitle="Current balance"
               amount={metrics.overdue + metrics.notDue}
               footer={
-                <div className="mt-2 space-y-1 text-[11px] text-slate-500">
+                <div className="mt-2 space-y-1 text-[11px] text-[var(--studio-muted)]">
                   <div>Overdue {currency.format(metrics.overdue)}</div>
                   <div>Not due {currency.format(metrics.notDue)}</div>
                 </div>
@@ -550,15 +557,18 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
       </div>
 
       <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
-        <div className="border-b border-slate-200 bg-white px-6 py-4">
+        <div
+          className="border-b border-[var(--studio-border)] px-6 py-4 backdrop-blur"
+          style={{background: 'var(--studio-surface-strong)'}}
+        >
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
-              <label className="flex items-center gap-2 text-sm text-slate-600">
+              <label className="flex items-center gap-2 text-sm text-[var(--studio-muted)]">
                 Status
                 <select
                   value={statusFilter}
                   onChange={(event) => setStatusFilter(event.currentTarget.value)}
-                  className="rounded-md border border-slate-300 px-2 py-1 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-md border border-[var(--studio-border-strong)] px-2 py-1 text-sm text-[var(--studio-text)] focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                 >
                   {STATUS_OPTIONS.map((option) => (
                     <option key={option.value} value={option.value}>
@@ -568,12 +578,12 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
                 </select>
               </label>
 
-              <label className="flex items-center gap-2 text-sm text-slate-600">
+              <label className="flex items-center gap-2 text-sm text-[var(--studio-muted)]">
                 Date
                 <select
                   value={dateFilter}
                   onChange={(event) => setDateFilter(event.currentTarget.value)}
-                  className="rounded-md border border-slate-300 px-2 py-1 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-md border border-[var(--studio-border-strong)] px-2 py-1 text-sm text-[var(--studio-text)] focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                 >
                   {DATE_OPTIONS.map((option) => (
                     <option key={option.value} value={option.value}>
@@ -590,17 +600,17 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
                 placeholder="Search number or customer…"
                 value={search}
                 onChange={(event) => setSearch(event.currentTarget.value)}
-                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 lg:w-64"
+                className="w-full rounded-md border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 lg:w-64"
               />
               {loading ? (
-                <div className="flex items-center justify-center rounded-md border border-slate-200 px-3 py-2">
+                <div className="flex items-center justify-center rounded-md border border-[var(--studio-border)] px-3 py-2">
                   <Spinner />
                 </div>
               ) : (
                 <button
                   type="button"
                   onClick={fetchInvoices}
-                  className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-600 shadow-sm"
+                  className="rounded-md border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-muted)] shadow-sm"
                 >
                   Refresh
                 </button>
@@ -609,9 +619,9 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
           </div>
         </div>
 
-        <div className="flex-1 min-h-0 overflow-auto bg-slate-50">
+        <div className="flex-1 min-h-0 overflow-auto" style={{background: 'var(--studio-surface-overlay)'}}>
           <div className="px-6 py-4">
-            <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+            <div className="rounded-xl border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-sm">
               <div style={{overflowX: 'auto'}}>
                 <div style={{borderBottom: '1px solid var(--card-border-color)'}}>
                   <div
@@ -632,7 +642,7 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
                       <input
                         ref={selectAllRef}
                         type="checkbox"
-                        className="h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
+                        className="h-4 w-4 rounded border-[var(--studio-border-strong)] text-emerald-600 focus:ring-emerald-500"
                         onChange={(event) => handleSelectAll(event.currentTarget.checked)}
                       />
                     </span>
@@ -664,14 +674,14 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
                     </div>
                   ) : loading ? (
                     <div
-                      className="text-sm text-slate-500"
+                      className="text-sm text-[var(--studio-muted)]"
                       style={{padding: '20px 24px', width: 'max-content', background: ROW_BACKGROUND_COLOR}}
                     >
                       Loading invoices…
                     </div>
                   ) : filteredInvoices.length === 0 ? (
                     <div
-                      className="text-sm text-slate-500"
+                      className="text-sm text-[var(--studio-muted)]"
                       style={{padding: '20px 24px', width: 'max-content', background: ROW_BACKGROUND_COLOR}}
                     >
                       No invoices match the current filters.
@@ -696,7 +706,7 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
                             width: 'max-content',
                             backgroundColor: rowBackground,
                           }}
-                          className="hover:bg-slate-100/60"
+                          className="hover:bg-[var(--studio-surface-overlay)]"
                         >
                           <span
                             onClick={(event) => {
@@ -706,7 +716,7 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
                           >
                             <input
                               type="checkbox"
-                              className="h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
+                              className="h-4 w-4 rounded border-[var(--studio-border-strong)] text-emerald-600 focus:ring-emerald-500"
                               checked={isSelected}
                               onChange={(event) => {
                                 event.stopPropagation()
@@ -724,14 +734,14 @@ const InvoiceDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>
                           >
                             {invoice.invoiceNumber}
                           </span>
-                          <span className="text-slate-600">
+                          <span className="text-[var(--studio-muted)]">
                             {invoice.invoiceDateIso ? shortDate.format(new Date(invoice.invoiceDateIso)) : '—'}
                           </span>
-                          <span className="text-slate-600">
+                          <span className="text-[var(--studio-muted)]">
                             {invoice.dueDateIso ? shortDate.format(new Date(invoice.dueDateIso)) : '—'}
                           </span>
-                          <span className="text-slate-700">{invoice.customerName}</span>
-                          <span style={{textAlign: 'right', fontVariantNumeric: 'tabular-nums'}} className="font-medium text-slate-900">
+                          <span className="text-[var(--studio-text)]">{invoice.customerName}</span>
+                          <span style={{textAlign: 'right', fontVariantNumeric: 'tabular-nums'}} className="font-medium text-[var(--studio-text)]">
                             {currency.format(invoice.amount || 0)}
                           </span>
                           <span>
@@ -778,10 +788,10 @@ const SummaryCard: React.FC<{
   footer?: React.ReactNode
 }> = ({title, subtitle, amount, footer}) => {
   return (
-    <div className="flex h-full min-h-[115px] flex-col justify-between rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm">
+    <div className="flex h-full min-h-[115px] flex-col justify-between rounded-md border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] px-3 py-2.5 shadow-sm">
       <div>
-        <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">{subtitle}</p>
-        <h3 className="mt-1 text-sm font-semibold text-slate-900">{title}</h3>
+        <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--studio-muted)]">{subtitle}</p>
+        <h3 className="mt-1 text-sm font-semibold text-[var(--studio-text)]">{title}</h3>
       </div>
       <div>
         <p className="text-base font-semibold text-slate-800">{currency.format(amount || 0)}</p>

--- a/components/studio/InvoiceVisualEditor.tsx
+++ b/components/studio/InvoiceVisualEditor.tsx
@@ -866,8 +866,8 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
     }
 
     return (
-      <tr className="border-b border-slate-200 last:border-b-0">
-        <td className="px-3 py-4 align-top text-sm text-slate-500">{index + 1}</td>
+      <tr className="border-b border-[var(--studio-border)] last:border-b-0">
+        <td className="px-3 py-4 align-top text-sm text-[var(--studio-muted)]">{index + 1}</td>
         <td className="relative px-3 py-3 align-top">
           <input
             type="text"
@@ -880,27 +880,27 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
               setTimeout(() => setDropdownVisible(false), 150)
             }}
             onChange={(event) => setQuery(event.currentTarget.value)}
-            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            className="w-full rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
           />
           {loadingOptions ? (
-            <div className="pointer-events-none absolute right-3 top-2.5 h-4 w-4 animate-spin rounded-full border-2 border-slate-300 border-t-slate-500" />
+            <div className="pointer-events-none absolute right-3 top-2.5 h-4 w-4 animate-spin rounded-full border-2 border-[var(--studio-border-strong)] border-t-slate-500" />
           ) : null}
           {dropdownVisible && results.length > 0 ? (
-            <div className="absolute left-0 right-0 top-full z-20 mt-2 max-h-56 overflow-auto rounded-lg border border-slate-200 bg-white shadow-xl">
+            <div className="absolute left-0 right-0 top-full z-20 mt-2 max-h-56 overflow-auto rounded-lg border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-xl">
               {results.map((product) => (
                 <button
                   key={product._id}
                   type="button"
-                  className="flex w-full flex-col gap-1 px-3 py-2 text-left hover:bg-slate-100"
+                  className="flex w-full flex-col gap-1 px-3 py-2 text-left hover:bg-[var(--studio-surface-soft)]"
                   onMouseDown={(event) => event.preventDefault()}
                   onClick={() => handleProductSelect(product)}
                 >
-                  <span className="text-sm font-semibold text-slate-900">{product.title}</span>
-                  <span className="text-xs text-slate-500">
+                  <span className="text-sm font-semibold text-[var(--studio-text)]">{product.title}</span>
+                  <span className="text-xs text-[var(--studio-muted)]">
                     {product.sku ? `SKU: ${product.sku}` : 'No SKU'} · ${fmt(product.price)}
                   </span>
                   {product.shortPlain ? (
-                    <span className="text-xs text-slate-500">{product.shortPlain}</span>
+                    <span className="text-xs text-[var(--studio-muted)]">{product.shortPlain}</span>
                   ) : null}
                 </button>
               ))}
@@ -910,7 +910,7 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
           !loadingOptions &&
           results.length === 0 &&
           query.trim().length >= 2 ? (
-            <div className="absolute left-0 right-0 top-full z-20 mt-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-500 shadow-xl">
+            <div className="absolute left-0 right-0 top-full z-20 mt-2 rounded-lg border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] px-3 py-2 text-sm text-[var(--studio-muted)] shadow-xl">
               No products found.
             </div>
           ) : null}
@@ -920,7 +920,7 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
             type="text"
             value={item.sku || ''}
             onChange={(event) => onUpdate(index, 'sku', event.currentTarget.value)}
-            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            className="w-full rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
             placeholder="SKU"
           />
         </td>
@@ -929,7 +929,7 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
             value={item.description || ''}
             onChange={(event) => onUpdate(index, 'description', event.currentTarget.value)}
             rows={2}
-            className="h-full w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            className="h-full w-full rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
             placeholder="Description"
           />
         </td>
@@ -942,7 +942,7 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
             onChange={(event) =>
               onUpdate(index, 'quantity', sanitizeNumber(event.currentTarget.value, 0))
             }
-            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-right text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            className="w-full rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-right text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
             placeholder="Qty"
           />
         </td>
@@ -954,7 +954,7 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
             onChange={(event) =>
               onUpdate(index, 'unitPrice', sanitizeNumber(event.currentTarget.value, 0))
             }
-            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-right text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            className="w-full rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-right text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
             placeholder="Rate"
           />
         </td>
@@ -964,27 +964,27 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
             step="0.01"
             value={Number.isFinite(amount) ? amount : ''}
             onChange={handleAmountChange}
-            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-right text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            className="w-full rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-right text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
             placeholder="Amount"
           />
           {taxRate > 0 ? (
-            <p className="mt-2 text-xs text-slate-500">
+            <p className="mt-2 text-xs text-[var(--studio-muted)]">
               Est. tax ({taxRate.toFixed(2)}%): ${fmt(estimatedTax)}
             </p>
           ) : null}
         </td>
-        <td className="px-3 py-3 align-top text-right text-sm font-semibold text-slate-700">
+        <td className="px-3 py-3 align-top text-right text-sm font-semibold text-[var(--studio-text)]">
           {taxRate > 0 ? `$${fmt(estimatedTax)}` : '—'}
         </td>
         <td className="px-3 py-3 align-top">
           <div className="flex flex-col items-stretch gap-2">
-            <div className="flex overflow-hidden rounded-md border border-slate-300">
+            <div className="flex overflow-hidden rounded-md border border-[var(--studio-border-strong)]">
               <button
                 type="button"
                 className={`flex-1 px-3 py-1 text-xs font-semibold transition ${
                   item.kind === 'product'
                     ? 'bg-slate-900 text-white'
-                    : 'bg-white text-slate-600 hover:bg-slate-100'
+                    : 'bg-[var(--studio-surface-strong)] text-[var(--studio-muted)] hover:bg-[var(--studio-surface-soft)]'
                 }`}
                 onClick={() => onKindChange(index, 'product')}
               >
@@ -995,7 +995,7 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                 className={`flex-1 px-3 py-1 text-xs font-semibold transition ${
                   item.kind === 'custom'
                     ? 'bg-slate-900 text-white'
-                    : 'bg-white text-slate-600 hover:bg-slate-100'
+                    : 'bg-[var(--studio-surface-strong)] text-[var(--studio-muted)] hover:bg-[var(--studio-surface-soft)]'
                 }`}
                 onClick={() => onKindChange(index, 'custom')}
               >
@@ -1017,25 +1017,25 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
 
   if (!displayed) {
     return (
-      <div className="flex h-full items-center justify-center bg-slate-100 text-slate-600">
+      <div className="flex h-full items-center justify-center bg-[var(--studio-surface-soft)] text-[var(--studio-muted)]">
         <p>No invoice data available.</p>
       </div>
     )
   }
 
   return (
-    <div className="h-full overflow-y-auto bg-slate-100 p-6">
+    <div className="h-full overflow-y-auto bg-[var(--studio-surface-soft)] p-6">
       <div className="mx-auto grid max-w-6xl gap-6">
-        <div className="overflow-hidden rounded-xl bg-white shadow-sm">
-          <div className="flex flex-wrap items-center justify-between gap-4 border-b border-slate-200 bg-slate-50 px-6 py-4">
+        <div className="overflow-hidden rounded-xl bg-[var(--studio-surface-strong)] shadow-sm">
+          <div className="flex flex-wrap items-center justify-between gap-4 border-b border-[var(--studio-border)] bg-[var(--studio-surface-soft)] px-6 py-4">
             <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Invoice</p>
-              <h1 className="text-2xl font-bold text-slate-900">
+              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">Invoice</p>
+              <h1 className="text-2xl font-bold text-[var(--studio-text)]">
                 {displayed.invoiceNumber || 'Untitled Invoice'}
               </h1>
-              <p className="text-sm text-slate-500">
+              <p className="text-sm text-[var(--studio-muted)]">
                 Status:{' '}
-                <span className="font-medium text-slate-700">{displayed.status || 'Pending'}</span>
+                <span className="font-medium text-[var(--studio-text)]">{displayed.status || 'Pending'}</span>
               </p>
             </div>
             <div className="flex items-center gap-3">
@@ -1043,7 +1043,7 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                 type="button"
                 onClick={resetChanges}
                 disabled={!isDirty || isSaving}
-                className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                className="rounded-lg border border-[var(--studio-border-strong)] px-4 py-2 text-sm font-medium text-[var(--studio-text)] transition hover:bg-[var(--studio-surface-soft)] disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Reset
               </button>
@@ -1058,34 +1058,34 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
             </div>
           </div>
 
-          <div className="grid gap-6 border-b border-slate-200 px-6 py-6 lg:grid-cols-2">
+          <div className="grid gap-6 border-b border-[var(--studio-border)] px-6 py-6 lg:grid-cols-2">
             <div className="grid gap-4">
-              <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
                 Invoice Date
                 <input
                   type="date"
                   value={state.invoiceDate}
                   onChange={(event) => updateState('invoiceDate', event.currentTarget.value)}
-                  className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                 />
               </label>
-              <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
                 Due Date
                 <input
                   type="date"
                   value={state.dueDate}
                   onChange={(event) => updateState('dueDate', event.currentTarget.value)}
-                  className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                 />
               </label>
-              <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
                 Payment Terms
                 <input
                   type="text"
                   value={state.paymentTerms}
                   onChange={(event) => updateState('paymentTerms', event.currentTarget.value)}
                   list="invoice-payment-terms"
-                  className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                   placeholder="Due on receipt"
                 />
                 <datalist id="invoice-payment-terms">
@@ -1094,22 +1094,22 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                   ))}
                 </datalist>
               </label>
-              <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
                 Service Rendered By
                 <input
                   type="text"
                   value={state.serviceRenderedBy}
                   onChange={(event) => updateState('serviceRenderedBy', event.currentTarget.value)}
-                  className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                   placeholder="Technician name"
                 />
               </label>
             </div>
             <div>
-              <dl className="space-y-2 text-sm text-slate-600">
+              <dl className="space-y-2 text-sm text-[var(--studio-muted)]">
                 <div className="flex justify-between">
                   <dt>Subtotal</dt>
-                  <dd className="font-medium text-slate-900">${totals.subtotal.toFixed(2)}</dd>
+                  <dd className="font-medium text-[var(--studio-text)]">${totals.subtotal.toFixed(2)}</dd>
                 </div>
                 <div className="flex justify-between">
                   <dt>
@@ -1118,25 +1118,25 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                       ? ` (${sanitizeNumber(state.discountValue, 0).toFixed(2)}%)`
                       : ''}
                   </dt>
-                  <dd className="font-medium text-slate-900">-${totals.discount.toFixed(2)}</dd>
+                  <dd className="font-medium text-[var(--studio-text)]">-${totals.discount.toFixed(2)}</dd>
                 </div>
                 <div className="flex justify-between">
                   <dt>Taxable Subtotal</dt>
-                  <dd className="font-medium text-slate-900">${totals.taxableBase.toFixed(2)}</dd>
+                  <dd className="font-medium text-[var(--studio-text)]">${totals.taxableBase.toFixed(2)}</dd>
                 </div>
                 <div className="flex justify-between">
                   <dt>Shipping</dt>
-                  <dd className="font-medium text-slate-900">${totals.shipping.toFixed(2)}</dd>
+                  <dd className="font-medium text-[var(--studio-text)]">${totals.shipping.toFixed(2)}</dd>
                 </div>
                 <div className="flex justify-between">
                   <dt>Tax ({sanitizeNumber(state.taxRate, 0).toFixed(2)}%)</dt>
-                  <dd className="font-medium text-slate-900">${totals.tax.toFixed(2)}</dd>
+                  <dd className="font-medium text-[var(--studio-text)]">${totals.tax.toFixed(2)}</dd>
                 </div>
-                <div className="flex justify-between border-t border-slate-200 pt-2 text-base font-semibold text-slate-900">
+                <div className="flex justify-between border-t border-[var(--studio-border)] pt-2 text-base font-semibold text-[var(--studio-text)]">
                   <dt>Total</dt>
                   <dd>${totals.total.toFixed(2)}</dd>
                 </div>
-                <div className="flex justify-between text-base font-semibold text-slate-900">
+                <div className="flex justify-between text-base font-semibold text-[var(--studio-text)]">
                   <dt>Deposit</dt>
                   <dd>-${depositValue.toFixed(2)}</dd>
                 </div>
@@ -1149,20 +1149,20 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
           </div>
 
           <div className="grid gap-4 px-6 pb-6 lg:grid-cols-2">
-            <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
               Discount Type
               <select
                 value={state.discountType}
                 onChange={(event) =>
                   updateState('discountType', event.currentTarget.value as 'amount' | 'percent')
                 }
-                className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
               >
                 <option value="amount">Amount ($)</option>
                 <option value="percent">Percent (%)</option>
               </select>
             </label>
-            <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
               Discount Value
               <input
                 type="number"
@@ -1171,10 +1171,10 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                 onChange={(event) =>
                   updateState('discountValue', sanitizeNumber(event.currentTarget.value, 0))
                 }
-                className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
               />
             </label>
-            <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
               Tax Rate (%)
               <input
                 type="number"
@@ -1183,10 +1183,10 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                 onChange={(event) =>
                   updateState('taxRate', sanitizeNumber(event.currentTarget.value, 0))
                 }
-                className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
               />
             </label>
-            <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
               Deposit Received
               <input
                 type="number"
@@ -1195,17 +1195,17 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                 onChange={(event) =>
                   updateState('depositAmount', sanitizeNumber(event.currentTarget.value, 0))
                 }
-                className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                 placeholder="0.00"
               />
             </label>
-            <label className="lg:col-span-2 flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <label className="lg:col-span-2 flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
               Payment Instructions
               <textarea
                 value={state.paymentInstructions}
                 onChange={(event) => updateState('paymentInstructions', event.currentTarget.value)}
                 rows={3}
-                className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                 placeholder="Tell your customer how to pay (e.g., card, bank, Venmo)."
               />
             </label>
@@ -1213,9 +1213,9 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
         </div>
 
         <section className="grid gap-6 lg:grid-cols-2">
-          <div className="rounded-xl bg-white p-6 shadow-sm">
+          <div className="rounded-xl bg-[var(--studio-surface-strong)] p-6 shadow-sm">
             <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-slate-900">Bill To</h2>
+              <h2 className="text-lg font-semibold text-[var(--studio-text)]">Bill To</h2>
               <button
                 type="button"
                 className="text-sm font-semibold text-blue-600 hover:text-blue-500"
@@ -1224,7 +1224,7 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                 Copy to Ship To
               </button>
             </div>
-            <div className="mt-4 grid gap-3 text-sm text-slate-700">
+            <div className="mt-4 grid gap-3 text-sm text-[var(--studio-text)]">
               {(
                 [
                   ['name', 'Full Name'],
@@ -1239,23 +1239,23 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                 ] as Array<[keyof InvoiceAddress, string]>
               ).map(([field, label]) => (
                 <label key={field} className="flex flex-col gap-1.5">
-                  <span className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                  <span className="text-xs font-medium uppercase tracking-wide text-[var(--studio-muted)]">
                     {label}
                   </span>
                   <input
                     type="text"
                     value={state.billTo[field] || ''}
                     onChange={(event) => updateAddress('billTo', field, event.currentTarget.value)}
-                    className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                   />
                 </label>
               ))}
             </div>
           </div>
 
-          <div className="rounded-xl bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-slate-900">Ship To</h2>
-            <div className="mt-4 grid gap-3 text-sm text-slate-700">
+          <div className="rounded-xl bg-[var(--studio-surface-strong)] p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-[var(--studio-text)]">Ship To</h2>
+            <div className="mt-4 grid gap-3 text-sm text-[var(--studio-text)]">
               {(
                 [
                   ['name', 'Full Name'],
@@ -1270,14 +1270,14 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                 ] as Array<[keyof InvoiceAddress, string]>
               ).map(([field, label]) => (
                 <label key={field} className="flex flex-col gap-1.5">
-                  <span className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                  <span className="text-xs font-medium uppercase tracking-wide text-[var(--studio-muted)]">
                     {label}
                   </span>
                   <input
                     type="text"
                     value={state.shipTo[field] || ''}
                     onChange={(event) => updateAddress('shipTo', field, event.currentTarget.value)}
-                    className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                   />
                 </label>
               ))}
@@ -1286,10 +1286,10 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
         </section>
 
         <section className="grid gap-6 lg:grid-cols-2">
-          <div className="rounded-xl bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-slate-900">Shipping Charge & Tracking</h2>
+          <div className="rounded-xl bg-[var(--studio-surface-strong)] p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-[var(--studio-text)]">Shipping Charge & Tracking</h2>
             <div className="mt-4 grid gap-4">
-              <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+              <label className="flex flex-col gap-2 text-sm font-medium text-[var(--studio-text)]">
                 Shipping Amount (USD)
                 <input
                   type="number"
@@ -1298,41 +1298,41 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                   onChange={(event) =>
                     updateState('amountShipping', sanitizeNumber(event.currentTarget.value, 0))
                   }
-                  className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                   placeholder="0.00"
                 />
               </label>
-              <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+              <label className="flex flex-col gap-2 text-sm font-medium text-[var(--studio-text)]">
                 Carrier
                 <input
                   type="text"
                   value={state.shippingCarrier}
                   onChange={(event) => updateState('shippingCarrier', event.currentTarget.value)}
-                  className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                   placeholder="UPS, USPS, FedEx…"
                 />
               </label>
-              <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+              <label className="flex flex-col gap-2 text-sm font-medium text-[var(--studio-text)]">
                 Tracking Number
                 <input
                   type="text"
                   value={state.trackingNumber}
                   onChange={(event) => updateState('trackingNumber', event.currentTarget.value)}
-                  className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                   placeholder="1Z…"
                 />
               </label>
-              <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+              <label className="flex flex-col gap-2 text-sm font-medium text-[var(--studio-text)]">
                 Tracking URL
                 <input
                   type="url"
                   value={state.trackingUrl}
                   onChange={(event) => updateState('trackingUrl', event.currentTarget.value)}
-                  className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                   placeholder="https://tracking.example.com/…"
                 />
               </label>
-              <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+              <label className="flex flex-col gap-2 text-sm font-medium text-[var(--studio-text)]">
                 Shipping Label URL
                 <input
                   type="url"
@@ -1340,33 +1340,33 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                   onChange={(event) =>
                     updateState('shippingLabelUrl', event.currentTarget.value)
                   }
-                  className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                   placeholder="https://label.example.com/…"
                 />
               </label>
             </div>
           </div>
 
-          <div className="rounded-xl bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-slate-900">Package Details</h2>
+          <div className="rounded-xl bg-[var(--studio-surface-strong)] p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-[var(--studio-text)]">Package Details</h2>
             <div className="mt-4 grid gap-4 sm:grid-cols-2">
-              <label className="flex flex-col gap-2 text-sm font-medium text-slate-700 sm:col-span-1">
+              <label className="flex flex-col gap-2 text-sm font-medium text-[var(--studio-text)] sm:col-span-1">
                 Weight
                 <input
                   type="number"
                   step="0.01"
                   value={state.weight?.value ?? 0}
                   onChange={(event) => updateWeightValue(event.currentTarget.value)}
-                  className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                   placeholder="5"
                 />
               </label>
-              <label className="flex flex-col gap-2 text-sm font-medium text-slate-700 sm:col-span-1">
+              <label className="flex flex-col gap-2 text-sm font-medium text-[var(--studio-text)] sm:col-span-1">
                 Unit
                 <select
                   value={state.weight?.unit || 'pound'}
                   onChange={(event) => updateWeightUnit(event.currentTarget.value)}
-                  className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                 >
                   <option value="pound">Pounds</option>
                   <option value="ounce">Ounces</option>
@@ -1383,39 +1383,39 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                   ['height', 'Height (in)'],
                 ] as Array<[keyof PackageDimensions, string]>
               ).map(([field, label]) => (
-                <label key={field} className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+                <label key={field} className="flex flex-col gap-2 text-sm font-medium text-[var(--studio-text)]">
                   {label}
                   <input
                     type="number"
                     step="0.01"
                     value={(state.dimensions?.[field] as number | undefined) ?? 0}
                     onChange={(event) => updateDimension(field, event.currentTarget.value)}
-                    className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    className="rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                     placeholder="0"
                   />
                 </label>
               ))}
             </div>
 
-            <div className="mt-6 rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
-              <h3 className="text-sm font-semibold text-slate-900">Selected Rate</h3>
+            <div className="mt-6 rounded-lg border border-[var(--studio-border)] bg-[var(--studio-surface-soft)] p-4 text-sm text-[var(--studio-text)]">
+              <h3 className="text-sm font-semibold text-[var(--studio-text)]">Selected Rate</h3>
               {state.selectedService ? (
                 <dl className="mt-3 space-y-1.5">
                   <div className="flex justify-between gap-4">
                     <dt>Service</dt>
-                    <dd className="font-medium text-slate-900">
+                    <dd className="font-medium text-[var(--studio-text)]">
                       {state.selectedService.service || state.selectedService.serviceCode || '—'}
                     </dd>
                   </div>
                   <div className="flex justify-between gap-4">
                     <dt>Carrier</dt>
-                    <dd className="font-medium text-slate-900">
+                    <dd className="font-medium text-[var(--studio-text)]">
                       {state.selectedService.carrier || state.selectedService.carrierId || '—'}
                     </dd>
                   </div>
                   <div className="flex justify-between gap-4">
                     <dt>Amount</dt>
-                    <dd className="font-medium text-slate-900">
+                    <dd className="font-medium text-[var(--studio-text)]">
                       {typeof state.selectedService.amount === 'number'
                         ? `$${fmt(state.selectedService.amount)}`
                         : '—'}
@@ -1424,7 +1424,7 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                   {typeof state.selectedService.deliveryDays === 'number' ? (
                     <div className="flex justify-between gap-4">
                       <dt>Est. Days</dt>
-                      <dd className="font-medium text-slate-900">
+                      <dd className="font-medium text-[var(--studio-text)]">
                         {state.selectedService.deliveryDays}
                       </dd>
                     </div>
@@ -1432,14 +1432,14 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                   {state.selectedService.estimatedDeliveryDate ? (
                     <div className="flex justify-between gap-4">
                       <dt>Est. Delivery</dt>
-                      <dd className="font-medium text-slate-900">
+                      <dd className="font-medium text-[var(--studio-text)]">
                         {formatDate(state.selectedService.estimatedDeliveryDate)}
                       </dd>
                     </div>
                   ) : null}
                 </dl>
               ) : (
-                <p className="text-sm text-slate-500">
+                <p className="text-sm text-[var(--studio-muted)]">
                   Shipping rate details appear once a rate is selected or a label is generated.
                 </p>
               )}
@@ -1447,27 +1447,27 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
           </div>
         </section>
 
-        <section className="rounded-xl bg-white p-6 shadow-sm">
-          <h2 className="text-lg font-semibold text-slate-900">Shipping History</h2>
+        <section className="rounded-xl bg-[var(--studio-surface-strong)] p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-[var(--studio-text)]">Shipping History</h2>
           {state.shippingLog.length > 0 ? (
             <ul className="mt-4 space-y-3">
               {state.shippingLog.map((entry, index) => (
                 <li
                   key={entry._key || `${entry.status || 'event'}-${index}`}
-                  className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-700 shadow-sm"
+                  className="rounded-lg border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] p-4 text-sm text-[var(--studio-text)] shadow-sm"
                 >
-                  <div className="flex flex-wrap items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  <div className="flex flex-wrap items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
                     <span>{trimString(entry.status) || 'Update'}</span>
                     <span>{formatDateTime(entry.createdAt)}</span>
                   </div>
                   {trimString(entry.message) ? (
-                    <p className="mt-2 text-sm text-slate-700">{entry.message}</p>
+                    <p className="mt-2 text-sm text-[var(--studio-text)]">{entry.message}</p>
                   ) : null}
-                  <div className="mt-2 flex flex-wrap gap-4 text-xs text-slate-500">
+                  <div className="mt-2 flex flex-wrap gap-4 text-xs text-[var(--studio-muted)]">
                     {trimString(entry.trackingNumber) ? (
                       <span>
                         Tracking:{' '}
-                        <span className="font-medium text-slate-700">
+                        <span className="font-medium text-[var(--studio-text)]">
                           {entry.trackingNumber}
                         </span>
                       </span>
@@ -1502,15 +1502,15 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
               ))}
             </ul>
           ) : (
-            <p className="mt-4 text-sm text-slate-500">No shipping events recorded yet.</p>
+            <p className="mt-4 text-sm text-[var(--studio-muted)]">No shipping events recorded yet.</p>
           )}
         </section>
 
-        <section className="rounded-xl bg-white p-6 shadow-sm">
+        <section className="rounded-xl bg-[var(--studio-surface-strong)] p-6 shadow-sm">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
-              <h2 className="text-lg font-semibold text-slate-900">Products & Services</h2>
-              <p className="text-sm text-slate-500">
+              <h2 className="text-lg font-semibold text-[var(--studio-text)]">Products & Services</h2>
+              <p className="text-sm text-[var(--studio-muted)]">
                 Add each line exactly as it should appear on the printed invoice.
               </p>
             </div>
@@ -1526,16 +1526,16 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                 type="button"
                 onClick={clearLineItems}
                 disabled={state.lineItems.length === 0}
-                className="inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex items-center justify-center rounded-lg border border-[var(--studio-border-strong)] px-4 py-2 text-sm font-semibold text-[var(--studio-text)] transition hover:bg-[var(--studio-surface-soft)] disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Clear all lines
               </button>
             </div>
           </div>
 
-          <div className="mt-6 overflow-hidden rounded-xl border border-slate-200">
+          <div className="mt-6 overflow-hidden rounded-xl border border-[var(--studio-border)]">
             <table className="min-w-full table-fixed">
-              <thead className="bg-slate-50 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+              <thead className="bg-[var(--studio-surface-soft)] text-[11px] font-semibold uppercase tracking-wide text-[var(--studio-muted)]">
                 <tr>
                   <th className="w-12 px-3 py-2 text-left">#</th>
                   <th className="w-64 px-3 py-2 text-left">Product / Service</th>
@@ -1548,10 +1548,10 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
                   <th className="w-40 px-3 py-2 text-right">Type</th>
                 </tr>
               </thead>
-              <tbody className="bg-white">
+              <tbody className="bg-[var(--studio-surface-strong)]">
                 {state.lineItems.length === 0 ? (
                   <tr>
-                    <td colSpan={9} className="px-6 py-10 text-center text-sm text-slate-500">
+                    <td colSpan={9} className="px-6 py-10 text-center text-sm text-[var(--studio-muted)]">
                       No line items yet. Click “Add product or service” to get started.
                     </td>
                   </tr>
@@ -1576,25 +1576,25 @@ const InvoiceVisualEditor: React.FC<DocumentViewProps> = ({document}) => {
         </section>
 
         <section className="grid gap-6 lg:grid-cols-2">
-          <div className="rounded-xl bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-slate-900">Customer Notes</h2>
+          <div className="rounded-xl bg-[var(--studio-surface-strong)] p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-[var(--studio-text)]">Customer Notes</h2>
             <textarea
               value={state.customerNotes}
               onChange={(event) => updateState('customerNotes', event.currentTarget.value)}
               rows={6}
               placeholder="Visible to the customer on the invoice."
-              className="mt-4 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              className="mt-4 w-full rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
             />
           </div>
 
-          <div className="rounded-xl bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-slate-900">Internal Notes</h2>
+          <div className="rounded-xl bg-[var(--studio-surface-strong)] p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-[var(--studio-text)]">Internal Notes</h2>
             <textarea
               value={state.internalNotes}
               onChange={(event) => updateState('internalNotes', event.currentTarget.value)}
               rows={6}
               placeholder="Private notes for your team."
-              className="mt-4 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              className="mt-4 w-full rounded-lg border border-[var(--studio-border-strong)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
             />
           </div>
         </section>

--- a/components/studio/QuotesDashboard.tsx
+++ b/components/studio/QuotesDashboard.tsx
@@ -305,22 +305,25 @@ const QuotesDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>(
   }
 
   return (
-    <div ref={ref} className="flex h-full min-h-0 flex-col bg-slate-100">
-      <header className="border-b border-slate-200 bg-white">
-        <div className="flex flex-col gap-4 px-6 py-4 lg:flex-row lg:items-center lg:justify-between">
+    <div ref={ref} className="studio-surface flex h-full min-h-0 flex-col rounded-3xl">
+      <header
+        className="border-b border-[var(--studio-border)] backdrop-blur"
+        style={{background: 'var(--studio-surface-strong)'}}
+      >
+        <div className="flex flex-col gap-4 px-6 py-5 lg:flex-row lg:items-center lg:justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900">Quotes &amp; Estimates</h2>
-            <p className="text-sm text-slate-500">
+            <h2 className="text-lg font-semibold text-[var(--studio-text)]">Quotes &amp; Estimates</h2>
+            <p className="text-sm text-[var(--studio-muted)]">
               Track drafts, send proposals, and convert accepted quotes to invoices.
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-3">
-            <label className="flex items-center gap-2 text-sm text-slate-600">
+            <label className="flex items-center gap-2 text-sm text-[var(--studio-muted)]">
               Status
               <select
                 value={statusFilter}
                 onChange={(event) => setStatusFilter(event.currentTarget.value)}
-                className="rounded-md border border-slate-300 px-2 py-1 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="rounded-lg border border-[var(--studio-border-strong)] bg-[var(--studio-surface)] px-2 py-1 text-sm text-[var(--studio-text)] shadow-sm transition focus:border-[var(--studio-accent)] focus:outline-none focus:ring-2 focus:ring-[rgba(37,99,235,0.25)]"
               >
                 {STATUS_OPTIONS.map((option) => (
                   <option key={option} value={option}>
@@ -329,12 +332,12 @@ const QuotesDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>(
                 ))}
               </select>
             </label>
-            <label className="flex items-center gap-2 text-sm text-slate-600">
+            <label className="flex items-center gap-2 text-sm text-[var(--studio-muted)]">
               Date
               <select
                 value={dateFilter}
                 onChange={(event) => setDateFilter(event.currentTarget.value)}
-                className="rounded-md border border-slate-300 px-2 py-1 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="rounded-lg border border-[var(--studio-border-strong)] bg-[var(--studio-surface)] px-2 py-1 text-sm text-[var(--studio-text)] shadow-sm transition focus:border-[var(--studio-accent)] focus:outline-none focus:ring-2 focus:ring-[rgba(37,99,235,0.25)]"
               >
                 {DATE_OPTIONS.map((option) => (
                   <option key={option.value} value={option.value}>
@@ -349,12 +352,12 @@ const QuotesDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>(
                 placeholder="Search quote or customer…"
                 value={search}
                 onChange={(event) => setSearch(event.currentTarget.value)}
-                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 lg:w-64"
+                className="w-full rounded-xl border border-[var(--studio-border-strong)] bg-[var(--studio-surface)] px-3 py-2 text-sm text-[var(--studio-text)] shadow-sm transition focus:border-[var(--studio-accent)] focus:outline-none focus:ring-2 focus:ring-[rgba(37,99,235,0.25)] lg:w-64"
               />
               <button
                 type="button"
                 onClick={() => router.navigateIntent('create', {type: 'quote'})}
-                className="inline-flex items-center rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-500"
+                className="inline-flex items-center rounded-full bg-emerald-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-500"
               >
                 Create quote
               </button>
@@ -363,9 +366,12 @@ const QuotesDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>(
         </div>
       </header>
 
-      <main className="flex flex-1 min-h-0 flex-col bg-slate-50">
+      <main
+        className="flex flex-1 min-h-0 flex-col"
+        style={{background: 'var(--studio-surface-overlay)'}}
+      >
         <div className="px-6 py-4">
-          <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="rounded-2xl border border-[var(--studio-border)] bg-[var(--studio-surface-strong)] shadow-lg">
             <div style={{overflowX: 'auto'}}>
               <div style={{borderBottom: '1px solid var(--card-border-color)'}}>
                 <div
@@ -385,7 +391,7 @@ const QuotesDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>(
                   <span style={{...STICKY_CHECKBOX_STYLE, background: HEADER_BACKGROUND, zIndex: 4}}>
                     <input
                       type="checkbox"
-                      className="h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
+                      className="h-4 w-4 rounded border-[var(--studio-border-strong)] text-emerald-600 focus:ring-emerald-500"
                       checked={hasSelections && selectedIds.size === filteredQuotes.length}
                       indeterminate={hasSelections && selectedIds.size < filteredQuotes.length}
                       onChange={(event) => handleSelectAll(event.currentTarget.checked)}
@@ -420,14 +426,14 @@ const QuotesDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>(
                   </div>
                 ) : loading ? (
                   <div
-                    className="flex items-center gap-2 text-sm text-slate-500"
+                    className="flex items-center gap-2 text-sm text-[var(--studio-muted)]"
                     style={{padding: '20px 24px', width: 'max-content', background: ROW_BACKGROUND}}
                   >
                     <Spinner muted /> Loading quotes…
                   </div>
                 ) : filteredQuotes.length === 0 ? (
                   <div
-                    className="text-sm text-slate-500"
+                    className="text-sm text-[var(--studio-muted)]"
                     style={{padding: '20px 24px', width: 'max-content', background: ROW_BACKGROUND}}
                   >
                     No quotes match the current filters.
@@ -453,7 +459,7 @@ const QuotesDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>(
                           width: 'max-content',
                           backgroundColor: rowBackground,
                         }}
-                        className="hover:bg-slate-100/60"
+                        className="hover:bg-[var(--studio-surface-overlay)]"
                       >
                         <span
                           onClick={(event) => {
@@ -463,7 +469,7 @@ const QuotesDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>(
                         >
                           <input
                             type="checkbox"
-                            className="h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
+                            className="h-4 w-4 rounded border-[var(--studio-border-strong)] text-emerald-600 focus:ring-emerald-500"
                             checked={isSelected}
                             onChange={(event) => {
                               event.stopPropagation()
@@ -481,16 +487,16 @@ const QuotesDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>(
                         >
                           {quote.quoteNumber}
                         </span>
-                        <span className="text-slate-600">
+                        <span className="text-[var(--studio-muted)]">
                           {quote.quoteDateIso ? shortDate.format(new Date(quote.quoteDateIso)) : '—'}
                         </span>
-                        <span className="text-slate-600">
+                        <span className="text-[var(--studio-muted)]">
                           {quote.expirationDateIso ? shortDate.format(new Date(quote.expirationDateIso)) : '—'}
                         </span>
-                        <span className="text-slate-700">{quote.customerName}</span>
+                        <span className="text-[var(--studio-text)]">{quote.customerName}</span>
                         <span
                           style={{textAlign: 'right', fontVariantNumeric: 'tabular-nums'}}
-                          className="font-medium text-slate-900"
+                          className="font-medium text-[var(--studio-text)]"
                         >
                           {currency.format(quote.amount || 0)}
                         </span>
@@ -503,7 +509,7 @@ const QuotesDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>(
                                   ? 'text-sky-600 bg-sky-50 border border-sky-100'
                                   : quote.status.toLowerCase() === 'approved'
                                     ? 'text-emerald-600 bg-emerald-50 border border-emerald-100'
-                                    : 'text-slate-600 bg-slate-100 border border-slate-200'
+                                    : 'text-[var(--studio-muted)] bg-[var(--studio-surface-soft)] border border-[var(--studio-border)]'
                             }`}
                           >
                             {quote.isConverted ? 'Converted' : quote.statusLabel || 'Draft'}
@@ -530,7 +536,7 @@ const QuotesDashboard = React.forwardRef<HTMLDivElement, Record<string, never>>(
                               disabled={quote.isConverted || isConverting}
                               className={`text-sm font-semibold ${
                                 quote.isConverted
-                                  ? 'text-slate-400'
+                                  ? 'text-[rgba(148,163,184,0.7)]'
                                   : 'text-emerald-600 hover:text-emerald-500'
                               } disabled:cursor-not-allowed`}
                             >

--- a/components/studio/SalesHub.tsx
+++ b/components/studio/SalesHub.tsx
@@ -14,26 +14,26 @@ const SalesHub = React.forwardRef<HTMLDivElement, Record<string, never>>((_props
   const [activeTab, setActiveTab] = useState<SalesTab>('orders')
 
   return (
-    <div ref={ref} className="flex h-full min-h-0 flex-col bg-slate-100">
-      <header className="border-b border-slate-200 bg-white">
-        <div className="flex flex-col gap-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="text-lg font-semibold text-slate-900">Sales &amp; Get Paid</h1>
-            <p className="text-sm text-slate-500">
+    <div ref={ref} className="studio-page">
+      <header className="studio-header">
+        <div className="studio-header__inner">
+          <div className="studio-header__titles">
+            <h1 className="studio-header__title">Sales &amp; Get Paid</h1>
+            <p className="studio-header__description">
               Manage orders, invoices, and in-person payments from one workspace.
             </p>
           </div>
-          <nav className="flex rounded-full border border-slate-200 bg-slate-100 p-1 text-sm font-medium text-slate-600 shadow-sm">
+          <nav className="studio-tablist" role="tablist" aria-label="Sales workspaces">
             {tabs.map((tab) => {
               const isActive = activeTab === tab.id
               return (
                 <button
                   key={tab.id}
                   type="button"
+                  role="tab"
+                  aria-selected={isActive}
                   onClick={() => setActiveTab(tab.id)}
-                  className={`rounded-full px-4 py-2 transition ${
-                    isActive ? 'bg-white text-slate-900 shadow-sm' : 'hover:text-slate-900'
-                  }`}
+                  className={`studio-tablist__button${isActive ? ' studio-tablist__button--active' : ''}`}
                 >
                   {tab.label}
                 </button>
@@ -43,12 +43,8 @@ const SalesHub = React.forwardRef<HTMLDivElement, Record<string, never>>((_props
         </div>
       </header>
 
-      <main className="flex flex-1 min-h-0 flex-col">
-        {activeTab === 'orders' ? (
-          <OrdersDashboard />
-        ) : (
-          <InvoiceDashboard />
-        )}
+      <main className="studio-content">
+        {activeTab === 'orders' ? <OrdersDashboard /> : <InvoiceDashboard />}
       </main>
     </div>
   )

--- a/components/studio/StudioLayout.tsx
+++ b/components/studio/StudioLayout.tsx
@@ -1,0 +1,19 @@
+import {useEffect} from 'react'
+import type {StudioLayoutProps} from 'sanity'
+
+export default function StudioLayout(props: StudioLayoutProps) {
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return undefined
+    }
+
+    const {body} = document
+    body.classList.add('sanity-studio-theme')
+
+    return () => {
+      body.classList.remove('sanity-studio-theme')
+    }
+  }, [])
+
+  return props.renderDefault(props)
+}

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -18,6 +18,7 @@ import { deskStructure } from './desk/deskStructure';
 import resolveDocumentActions from './resolveDocumentActions';
 import ShippingCalendar from './components/studio/ShippingCalendar';
 import AdminTools from './components/studio/AdminTools';
+import StudioLayout from './components/studio/StudioLayout';
 
 const hasProcess = typeof process !== 'undefined' && typeof process.cwd === 'function';
 const joinSegments = (...segments: string[]) => segments.filter(Boolean).join('/');
@@ -77,6 +78,11 @@ export default defineConfig({
 
   schema: {
     types: schemaTypes,
+  },
+  studio: {
+    components: {
+      layout: StudioLayout,
+    },
   },
   vite: {
     resolve: {

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -9,3 +9,161 @@ html {
 body {
   min-height: 100%;
 }
+
+@layer base {
+  body.sanity-studio-theme {
+    --studio-body-background: radial-gradient(circle at 20% -10%, #e2e8f0 0%, #cbd5f5 45%, #94a3b8 100%);
+    --studio-surface: rgba(255, 255, 255, 0.92);
+    --studio-surface-strong: #ffffff;
+    --studio-surface-soft: rgba(248, 250, 252, 0.7);
+    --studio-surface-overlay: rgba(248, 250, 252, 0.55);
+    --studio-border: rgba(148, 163, 184, 0.35);
+    --studio-border-strong: rgba(100, 116, 139, 0.4);
+    --studio-text: #0f172a;
+    --studio-muted: rgba(71, 85, 105, 0.85);
+    --studio-accent: #2563eb;
+    --studio-accent-strong: #1e293b;
+    --studio-accent-muted: rgba(37, 99, 235, 0.12);
+    --studio-shadow: 0 18px 45px rgba(15, 23, 42, 0.18);
+    --studio-backdrop: rgba(148, 163, 184, 0.25);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body.sanity-studio-theme {
+      --studio-body-background: radial-gradient(circle at 15% -10%, #1e293b 0%, #0f172a 45%, #020617 100%);
+      --studio-surface: rgba(15, 23, 42, 0.85);
+      --studio-surface-strong: rgba(15, 23, 42, 0.94);
+      --studio-surface-soft: rgba(30, 41, 59, 0.55);
+      --studio-surface-overlay: rgba(15, 23, 42, 0.6);
+      --studio-border: rgba(148, 163, 184, 0.28);
+      --studio-border-strong: rgba(148, 163, 184, 0.4);
+      --studio-text: #f8fafc;
+      --studio-muted: rgba(226, 232, 240, 0.78);
+      --studio-accent: #60a5fa;
+      --studio-accent-strong: #e2e8f0;
+      --studio-accent-muted: rgba(96, 165, 250, 0.22);
+      --studio-shadow: 0 22px 55px rgba(2, 6, 23, 0.55);
+      --studio-backdrop: rgba(2, 6, 23, 0.55);
+    }
+  }
+
+  body.sanity-studio-theme *,
+  body.sanity-studio-theme *::before,
+  body.sanity-studio-theme *::after {
+    box-sizing: border-box;
+  }
+
+  body.sanity-studio-theme {
+    background: var(--studio-body-background);
+    color: var(--studio-text);
+    font-family: 'Inter', 'SF Pro Display', 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    display: flex;
+    flex-direction: column;
+  }
+
+  body.sanity-studio-theme #__next,
+  body.sanity-studio-theme #sanity,
+  body.sanity-studio-theme #root {
+    flex: 1 1 auto;
+    min-height: 100%;
+  }
+}
+
+@layer components {
+  body.sanity-studio-theme .studio-page {
+    @apply flex h-full min-h-0 flex-col overflow-hidden;
+    background: var(--studio-surface);
+    color: var(--studio-text);
+    border-radius: 1.75rem;
+    border: 1px solid var(--studio-border);
+    box-shadow: var(--studio-shadow);
+    backdrop-filter: blur(24px);
+  }
+
+  body.sanity-studio-theme .studio-header {
+    border-bottom: 1px solid var(--studio-border);
+    background: var(--studio-surface-strong);
+    backdrop-filter: blur(24px);
+  }
+
+  body.sanity-studio-theme .studio-header__inner {
+    @apply flex flex-col gap-4 px-6 py-6 lg:flex-row lg:items-center lg:justify-between;
+  }
+
+  body.sanity-studio-theme .studio-header__titles {
+    @apply flex flex-col gap-1;
+  }
+
+  body.sanity-studio-theme .studio-header__title {
+    @apply text-xl font-semibold tracking-tight;
+    color: var(--studio-text);
+  }
+
+  body.sanity-studio-theme .studio-header__description {
+    @apply text-sm;
+    color: var(--studio-muted);
+  }
+
+  body.sanity-studio-theme .studio-header__actions {
+    @apply flex flex-col gap-4 lg:flex-row lg:items-center lg:gap-6;
+  }
+
+  body.sanity-studio-theme .studio-tablist {
+    @apply inline-flex items-center gap-1 rounded-full px-1 py-1 text-sm font-medium;
+    border: 1px solid var(--studio-border);
+    background: var(--studio-surface-soft);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+  }
+
+  body.sanity-studio-theme .studio-tablist__button {
+    @apply rounded-full px-4 py-2 transition;
+    color: var(--studio-muted);
+    background: transparent;
+  }
+
+  body.sanity-studio-theme .studio-tablist__button:hover {
+    color: var(--studio-text);
+    box-shadow: inset 0 0 0 999px rgba(148, 163, 184, 0.1);
+  }
+
+  body.sanity-studio-theme .studio-tablist__button--active {
+    color: var(--studio-accent-strong);
+    background: var(--studio-accent-muted);
+    box-shadow: 0 12px 28px rgba(37, 99, 235, 0.22);
+  }
+
+  body.sanity-studio-theme .studio-content {
+    @apply flex flex-1 min-h-0 flex-col gap-6 overflow-hidden;
+    padding: clamp(1.5rem, 1.5vw + 1.25rem, 2.5rem);
+    background: transparent;
+  }
+
+  body.sanity-studio-theme .studio-section-title {
+    @apply text-sm font-semibold uppercase tracking-[0.12em];
+    color: var(--studio-muted);
+  }
+
+  body.sanity-studio-theme .studio-surface {
+    background: var(--studio-surface-strong);
+    border: 1px solid var(--studio-border);
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+  }
+
+  body.sanity-studio-theme .studio-surface-soft {
+    background: var(--studio-surface-soft);
+    border: 1px solid var(--studio-border);
+  }
+
+  body.sanity-studio-theme .studio-scroll-area {
+    @apply overflow-auto rounded-2xl;
+    border: 1px solid var(--studio-border);
+    background: var(--studio-surface-strong);
+  }
+
+  body.sanity-studio-theme .studio-badge {
+    @apply inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-semibold;
+    background: var(--studio-accent-muted);
+    color: var(--studio-accent-strong);
+  }
+}


### PR DESCRIPTION
## Summary
- add a custom Studio layout that tags the document body with a `sanity-studio-theme` class while the studio is mounted
- scope the studio surface variables and utility classes to that class so the rest of the site retains its existing styles

## Testing
- `npm run build` *(fails: Sanity CLI cannot fetch remote module in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eff7936840832cb9eb20bbb1b1e5b8