### PR TITLE
Fix Shipping Calendar workspace client fallback

### DIFF
--- a/components/studio/ShippingCalendar.tsx
+++ b/components/studio/ShippingCalendar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { useClient } from 'sanity'
 import { Card, Heading, Text, Stack, Box } from '@sanity/ui'
+import { useWorkspaceClient } from '../../utils/useWorkspaceClient'
 
 type RawShippingLabel = {
   _id: string
@@ -39,7 +39,7 @@ const StatusBadge: React.FC<{ status?: string }> = ({ status }) => {
 };
 
 export default function ShippingCalendar() {
-  const client = useClient({ apiVersion: '2024-04-10' })
+  const client = useWorkspaceClient({ apiVersion: '2024-04-10' })
   const [events, setEvents] = useState<Event[]>([])
   const [loading, setLoading] = useState<boolean>(true)
   const calcomEmbedUrl = useMemo(

--- a/utils/useWorkspaceClient.ts
+++ b/utils/useWorkspaceClient.ts
@@ -1,0 +1,34 @@
+import {createClient} from '@sanity/client'
+import {useContext, useMemo} from 'react'
+import {useClient} from 'sanity'
+import {WorkspaceContext} from 'sanity/_singletons'
+
+type UseClientOptions = Parameters<typeof useClient>[0]
+
+const DEFAULT_PROJECT_ID = process.env.SANITY_STUDIO_PROJECT_ID || 'r4og35qd'
+const DEFAULT_DATASET = process.env.SANITY_STUDIO_DATASET || 'production'
+const FALLBACK_API_VERSION = '2024-10-01'
+
+export function useWorkspaceClient(options?: UseClientOptions) {
+  const workspace = useContext(WorkspaceContext)
+
+  if (workspace) {
+    return useClient(options)
+  }
+
+  const apiVersion = options?.apiVersion
+
+  return useMemo(
+    () =>
+      createClient({
+        projectId: DEFAULT_PROJECT_ID,
+        dataset: DEFAULT_DATASET,
+        apiVersion: apiVersion || FALLBACK_API_VERSION,
+        useCdn: false,
+        withCredentials: true,
+        perspective: 'published',
+        ignoreBrowserTokenWarning: true,
+      }),
+    [apiVersion],
+  )
+}


### PR DESCRIPTION
## Summary
- add a workspace-aware Sanity client hook that falls back to a standalone client when no Workspace context is present
- update the Shipping Calendar studio tool to use the new hook so it can run outside of the workspace provider without crashing

## Testing
- npm run build *(fails: fetch failed when reaching Sanity CDN in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0afa2c258832cbae770b58ff71ed2