### PR TITLE
Improve Stripe failure diagnostics for Affirm cancellations

### DIFF
--- a/schemaTypes/documents/invoiceContent.tsx
+++ b/schemaTypes/documents/invoiceContent.tsx
@@ -928,6 +928,8 @@ export default defineType({
     defineField({ name: 'customerEmail', title: 'Customer Email', type: 'string' }),
     defineField({ name: 'stripeInvoiceId', title: 'Stripe Invoice ID', type: 'string', readOnly: true }),
     defineField({ name: 'stripeInvoiceStatus', title: 'Stripe Invoice Status', type: 'string', readOnly: true }),
+    defineField({ name: 'paymentFailureCode', title: 'Payment Failure Code', type: 'string', readOnly: true }),
+    defineField({ name: 'paymentFailureMessage', title: 'Payment Failure Message', type: 'text', readOnly: true }),
     defineField({ name: 'stripeHostedInvoiceUrl', title: 'Stripe Hosted Invoice URL', type: 'url', readOnly: true }),
     defineField({ name: 'stripeInvoicePdf', title: 'Stripe Invoice PDF', type: 'url', readOnly: true }),
     defineField({ name: 'stripeLastSyncedAt', title: 'Stripe Last Synced', type: 'datetime', readOnly: true }),


### PR DESCRIPTION
## Summary
- pull the latest Stripe charge information when a payment intent fails so checkout declines such as Affirm cancellations surface meaningful codes and messages
- store those failure codes/messages on associated invoices for staff visibility in Studio

## Testing
- npx eslint netlify/functions/stripeWebhook.ts schemaTypes/documents/invoiceContent.tsx


------
https://chatgpt.com/codex/tasks/task_e_68f84b2458c8832ca70e923c3835d9ad