### PR TITLE
Fix Stripe Checkout session inspect script expansion

### DIFF
--- a/scripts/inspect-checkout-session.ts
+++ b/scripts/inspect-checkout-session.ts
@@ -18,7 +18,7 @@ if (!secret) {
 async function main() {
   const stripe = new Stripe(secret, { apiVersion: '2024-06-20' })
   const session = await stripe.checkout.sessions.retrieve(sessionId, {
-    expand: ['shipping_details', 'customer', 'total_details.breakdown'],
+    expand: ['customer', 'total_details.breakdown'],
   })
 
   console.log('metadata:', session.metadata)


### PR DESCRIPTION
## Summary
- stop requesting expansion of shipping_details when retrieving checkout sessions in the inspect script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f84e818628832cbd0727368f9ea0bb