### PR TITLE
Preserve cancelled invoice status on failure recording

### DIFF
--- a/netlify/functions/stripeWebhook.ts
+++ b/netlify/functions/stripeWebhook.ts
@@ -1354,7 +1354,7 @@ export const handler: Handler = async (event) => {
                 invoiceStripeStatus: webhookEvent.type,
                 invoiceStatus:
                   webhookEvent.type === 'invoice.updated' && invoice.status === 'uncollectible'
-                    ? 'pending'
+                    ? 'cancelled'
                     : undefined,
               })
             }


### PR DESCRIPTION
## Summary
- ensure invoice.updated events that set invoices to uncollectible keep the cancelled status when recording the payment failure

## Testing
- npx eslint netlify/functions/stripeWebhook.ts schemaTypes/documents/invoiceContent.tsx

------
https://chatgpt.com/codex/tasks/task_e_68f860003078832cb6015daa702953cb