### PR TITLE
Preserve cancelled invoice status during failure sync

### DIFF
--- a/netlify/functions/stripeWebhook.ts
+++ b/netlify/functions/stripeWebhook.ts
@@ -1352,10 +1352,7 @@ export const handler: Handler = async (event) => {
             if (paymentIntent) {
               await markPaymentIntentFailure(paymentIntent, {
                 invoiceStripeStatus: webhookEvent.type,
-                invoiceStatus:
-                  webhookEvent.type === 'invoice.updated' && invoice.status === 'uncollectible'
-                    ? 'cancelled'
-                    : undefined,
+                invoiceStatus: invoice.status === 'uncollectible' ? 'cancelled' : undefined,
               })
             }
           }


### PR DESCRIPTION
## Summary
- ensure markPaymentIntentFailure keeps invoices with Stripe status `uncollectible` in the cancelled state when recording payment failures

## Testing
- npx eslint netlify/functions/stripeWebhook.ts schemaTypes/documents/invoiceContent.tsx

------
https://chatgpt.com/codex/tasks/task_e_68f861ff2ec0832c8d51215e84d408a8