### PR TITLE
Sync Stripe guest metadata into customer records

### DIFF
--- a/netlify/lib/customerSnapshot.ts
+++ b/netlify/lib/customerSnapshot.ts
@@ -1,4 +1,5 @@
 import type { SanityClient } from '@sanity/client'
+import { mapStripeMetadata } from './stripeMetadata'
 
 type ShippingLike = {
   name?: string | null
@@ -30,6 +31,8 @@ type UpdateCustomerArgs = {
   stripeCustomerId?: string | null
   stripeSyncTimestamp?: string | null
   customerName?: string | null
+  metadata?: Record<string, unknown> | null
+  defaultRoles?: string[]
 }
 
 function splitName(value?: string | null): { firstName?: string; lastName?: string } {
@@ -124,6 +127,8 @@ export async function updateCustomerProfileForOrder({
   stripeCustomerId,
   stripeSyncTimestamp,
   customerName,
+  metadata,
+  defaultRoles,
 }: UpdateCustomerArgs): Promise<void> {
   const email = (rawEmail || '').toLowerCase().trim()
   if (!initialCustomerId && !email) return
@@ -157,10 +162,12 @@ export async function updateCustomerProfileForOrder({
   // Create a customer document if none exists but we have an email.
   if (!customerId && email) {
     const nameParts = splitName(shippingFromOrder?.name || customerName || '')
+    const metadataEntries = mapStripeMetadata(metadata as Record<string, unknown> | null)
+    const roles = Array.isArray(defaultRoles) && defaultRoles.length ? defaultRoles : ['customer']
     const payload: Record<string, any> = {
       _type: 'customer',
       email,
-      roles: ['customer'],
+      roles,
       firstName: nameParts.firstName || undefined,
       lastName: nameParts.lastName || undefined,
       shippingAddress: shippingNormalized,
@@ -180,6 +187,8 @@ export async function updateCustomerProfileForOrder({
         : undefined,
       stripeCustomerId: stripeCustomerId || undefined,
       stripeLastSyncedAt: stripeSyncTimestamp || undefined,
+      ...(shippingFromOrder?.phone ? { phone: shippingFromOrder.phone } : {}),
+      ...(metadataEntries ? { stripeMetadata: metadataEntries } : {}),
       updatedAt: new Date().toISOString(),
     }
     try {
@@ -332,6 +341,14 @@ export async function updateCustomerProfileForOrder({
   if (legacyShippingString) patch.address = legacyShippingString
   if (nameParts.firstName && !customerDoc?.firstName) patch.firstName = nameParts.firstName
   if (nameParts.lastName && !customerDoc?.lastName) patch.lastName = nameParts.lastName
+  if (shippingFromOrder?.phone && !customerDoc?.phone) patch.phone = shippingFromOrder.phone
+
+  const metadataEntries = mapStripeMetadata(metadata as Record<string, unknown> | null)
+  if (metadataEntries) patch.stripeMetadata = metadataEntries
+
+  const roles = Array.isArray(defaultRoles) && defaultRoles.length ? defaultRoles : ['customer']
+  const hasRoles = Array.isArray(customerDoc?.roles) && customerDoc.roles.length
+  if (!hasRoles && roles.length) patch.roles = roles
 
   try {
     await sanity.patch(customerId).set(patch).commit({ autoGenerateArrayKeys: true })

--- a/netlify/lib/stripeMetadata.ts
+++ b/netlify/lib/stripeMetadata.ts
@@ -1,0 +1,33 @@
+export type StripeMetadata = Record<string, unknown> | null | undefined
+
+export type StripeMetadataEntry = {
+  _type: 'stripeMetadataEntry'
+  key: string
+  value: string
+}
+
+export function mapStripeMetadata(metadata: StripeMetadata): StripeMetadataEntry[] | undefined {
+  if (!metadata) return undefined
+  const entries = Object.entries(metadata).reduce<StripeMetadataEntry[]>((acc, [key, raw]) => {
+    const normalizedKey = key?.toString().trim()
+    if (!normalizedKey) return acc
+    if (raw === undefined || raw === null) return acc
+    let value: string
+    if (typeof raw === 'string') {
+      value = raw
+    } else if (typeof raw === 'number' || typeof raw === 'boolean') {
+      value = String(raw)
+    } else {
+      try {
+        value = JSON.stringify(raw)
+      } catch {
+        value = String(raw)
+      }
+    }
+    const trimmedValue = value.trim()
+    if (!trimmedValue) return acc
+    acc.push({ _type: 'stripeMetadataEntry', key: normalizedKey, value: trimmedValue })
+    return acc
+  }, [])
+  return entries.length ? entries : undefined
+}

--- a/schemaTypes/documents/customer.ts
+++ b/schemaTypes/documents/customer.ts
@@ -64,13 +64,14 @@ export default defineType({
       options: {
         list: [
           { title: 'Customer', value: 'customer' },
+          { title: 'Guest (no account)', value: 'guest' },
           { title: 'Vendor', value: 'vendor' },
           { title: 'Admin', value: 'admin' },
         ],
       },
       validation: (Rule) => Rule.required().min(1).warning('Users should have at least one role'),
       description:
-        'Used by FAS Auth to gate access to portals. Most users should stay as Customer unless granted vendor/admin access.',
+        'Used by FAS Auth to gate access to portals. Guests are imported from Stripe and do not have login access.',
     }),
     defineField({
       name: 'passwordHash',
@@ -106,6 +107,13 @@ export default defineType({
       title: 'Wishlist Items',
       type: 'array',
       of: [{ type: 'reference', to: [{ type: 'product' }] }]
+    }),
+    defineField({
+      name: 'stripeMetadata',
+      title: 'Latest Stripe Metadata',
+      type: 'array',
+      of: [{ type: 'stripeMetadataEntry' }],
+      readOnly: true,
     }),
     // Marketing preferences
     defineField({ name: 'emailOptIn', title: 'Email Opt‑In', type: 'boolean', initialValue: false }),

--- a/schemaTypes/index.ts
+++ b/schemaTypes/index.ts
@@ -79,6 +79,7 @@ import { shopifyProductType } from './objects/shopify/shopifyProductType'
 import { shopifyProductVariantType } from './objects/shopify/shopifyProductVariantType'
 import { spotType } from './objects/hotspot/spotType'
 import { stripePriceSnapshotType } from './objects/stripePriceSnapshotType'
+import { stripeMetadataEntryType } from './objects/stripeMetadataEntry'
 import tune from './documents/tune'
 import wheelQuote from './documents/wheelQuote'
 
@@ -162,6 +163,7 @@ const objects = [
   shopifyProductVariantType,
   spotType,
   stripePriceSnapshotType,
+  stripeMetadataEntryType,
   {
     name: 'siteSettings',
     type: 'document',

--- a/schemaTypes/objects/stripeMetadataEntry.ts
+++ b/schemaTypes/objects/stripeMetadataEntry.ts
@@ -1,0 +1,20 @@
+import { defineField, defineType } from 'sanity'
+
+export const stripeMetadataEntryType = defineType({
+  name: 'stripeMetadataEntry',
+  title: 'Stripe Metadata Entry',
+  type: 'object',
+  fields: [
+    defineField({ name: 'key', title: 'Key', type: 'string' }),
+    defineField({ name: 'value', title: 'Value', type: 'string' }),
+  ],
+  preview: {
+    select: { key: 'key', value: 'value' },
+    prepare({ key, value }) {
+      return {
+        title: key || '(empty key)',
+        subtitle: value || '',
+      }
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add a reusable schema/object for storing Stripe metadata entries and expose a "Guest" role option on customers
- persist the latest Stripe metadata when syncing customer records, including for expired checkout sessions
- update checkout-expired handling to create or refresh guest customer documents with shipping details instead of leaving nulls

## Testing
- pnpm exec tsc --noEmit *(fails: components/studio/ShippingCalendar.tsx:96, netlify/functions/stripeWebhook.ts:1625, utils/useWorkspaceClient.ts:16)*

------
https://chatgpt.com/codex/tasks/task_e_68f88d5f66a4832ca8c5b1d1d554e072