### PR TITLE
Prefer metadata shipping amount when syncing orders

### DIFF
--- a/netlify/functions/reprocessStripeSession.ts
+++ b/netlify/functions/reprocessStripeSession.ts
@@ -306,7 +306,7 @@ export const handler: Handler = async (event) => {
       const fallback = Number(cleaned)
       return Number.isFinite(fallback) ? fallback : undefined
     })()
-    if (amountShipping === undefined && shippingAmountFromMetadata !== undefined) {
+    if (shippingAmountFromMetadata !== undefined) {
       amountShipping = shippingAmountFromMetadata
     }
     const userIdMeta = (
@@ -415,6 +415,9 @@ export const handler: Handler = async (event) => {
         amount: shippingAmountFromMetadata !== undefined ? shippingAmountFromMetadata : amountShipping,
         currency: metadataShippingCurrency || (currency ? currency.toUpperCase() : undefined) || 'USD',
       }
+    }
+    if (shippingAmountFromMetadata !== undefined) {
+      baseDoc.amountShipping = shippingAmountFromMetadata
     }
 
     if (metadataShippingCarrier) {

--- a/netlify/functions/stripeWebhook.ts
+++ b/netlify/functions/stripeWebhook.ts
@@ -1574,7 +1574,7 @@ export const handler: Handler = async (event) => {
           const fallback = Number(cleaned)
           return Number.isFinite(fallback) ? fallback : undefined
         })()
-        if (amountShipping === undefined && shippingAmountFromMetadata !== undefined) {
+        if (shippingAmountFromMetadata !== undefined) {
           amountShipping = shippingAmountFromMetadata
         }
         const orderNumber = await resolveOrderNumber({
@@ -1776,6 +1776,10 @@ export const handler: Handler = async (event) => {
               amount: shippingAmountFromMetadata !== undefined ? shippingAmountFromMetadata : amountShipping,
               currency: metadataShippingCurrency || (currency ? currency.toUpperCase() : undefined) || 'USD',
             }
+          }
+
+          if (shippingAmountFromMetadata !== undefined) {
+            baseDoc.amountShipping = shippingAmountFromMetadata
           }
 
           const orderSlug = createOrderSlug(orderNumber, stripeSessionId)


### PR DESCRIPTION
## Summary
- ensure the Stripe webhook always prefers the shipping amount provided via metadata when building order documents
- apply the same metadata override when reprocessing Stripe sessions so order totals stay consistent

## Testing
- npm run lint *(fails: existing lint warnings in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68f93c723144832c8e1879d04acc0edf