### PR TITLE
Include Stripe metadata in product snapshots

### DIFF
--- a/schemaTypes/documents/product.ts
+++ b/schemaTypes/documents/product.ts
@@ -265,6 +265,14 @@ const product = defineType({
       group: 'pricing',
     }),
     defineField({
+      name: 'stripeMetadata',
+      title: 'Stripe Product Metadata',
+      type: 'array',
+      of: [{ type: 'stripeMetadataEntry' }],
+      readOnly: true,
+      group: 'pricing',
+    }),
+    defineField({
       name: 'availability',
       title: 'Availability',
       type: 'string',

--- a/schemaTypes/objects/stripePriceSnapshotType.ts
+++ b/schemaTypes/objects/stripePriceSnapshotType.ts
@@ -17,6 +17,16 @@ export const stripePriceSnapshotType = defineType({
     defineField({ name: 'active', title: 'Active', type: 'boolean', readOnly: true }),
     defineField({ name: 'livemode', title: 'Live Mode', type: 'boolean', readOnly: true }),
     defineField({ name: 'createdAt', title: 'Created At', type: 'datetime', readOnly: true }),
+    defineField({ name: 'lookupKey', title: 'Lookup Key', type: 'string', readOnly: true }),
+    defineField({ name: 'taxBehavior', title: 'Tax Behavior', type: 'string', readOnly: true }),
+    defineField({
+      name: 'metadata',
+      title: 'Metadata',
+      type: 'array',
+      of: [{ type: 'stripeMetadataEntry' }],
+      readOnly: true,
+      options: { layout: 'grid' },
+    }),
   ],
   preview: {
     select: {


### PR DESCRIPTION
## Summary
- import and store Stripe metadata when syncing the product catalog
- expose product-level metadata and additional price fields in the Sanity schema
- capture price lookup keys and tax behavior so Stripe snapshots stay comprehensive

## Testing
- npm run lint *(fails: existing warnings in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68fab5e4c14c832ca845fe5ec7541dd2