### PR TITLE
Fix wrap prop warnings in Sanity dashboards

### DIFF
--- a/packages/sanity-config/src/components/studio/FinancialDashboard.tsx
+++ b/packages/sanity-config/src/components/studio/FinancialDashboard.tsx
@@ -307,7 +307,12 @@ const FinancialDashboard = React.forwardRef<HTMLDivElement, Record<string, never
       }}
     >
       <Stack space={4}>
-        <Flex align="center" justify="space-between" wrap="wrap" gap={3}>
+        <Flex
+          align="center"
+          justify="space-between"
+          gap={3}
+          style={{flexWrap: 'wrap'}}
+        >
           <Stack space={1}>
             <Heading size={3}>Financial dashboard</Heading>
             {summary ? (
@@ -316,7 +321,7 @@ const FinancialDashboard = React.forwardRef<HTMLDivElement, Record<string, never
               </Text>
             ) : null}
           </Stack>
-          <Flex gap={2} wrap="wrap">
+          <Flex gap={2} style={{flexWrap: 'wrap'}}>
             {RANGE_PRESETS.map((preset) => (
               <Button
                 key={preset.value}
@@ -435,7 +440,12 @@ function ProfitLossCard({summary, range}: {summary: Summary; range: RangePreset}
           />
         </Stack>
 
-        <Flex justify="space-between" align="center" wrap="wrap" gap={2}>
+        <Flex
+          justify="space-between"
+          align="center"
+          gap={2}
+          style={{flexWrap: 'wrap'}}
+        >
           <Text size={1} muted>
             {previousTransactions} transactions this period
           </Text>
@@ -462,7 +472,7 @@ function ExpensesCard({summary}: {summary: Summary}) {
           <TrendBadge value={change} />
         </Flex>
 
-        <Flex align="center" gap={4} wrap="wrap">
+        <Flex align="center" gap={4} style={{flexWrap: 'wrap'}}>
           <DonutChart
             size={140}
             thickness={28}
@@ -516,7 +526,7 @@ function CashFlowCard({summary}: {summary: Summary}) {
           height={120}
         />
 
-        <Flex gap={3} wrap="wrap">
+        <Flex gap={3} style={{flexWrap: 'wrap'}}>
           <SnapshotMetric label="Money in" value={moneyIn} tone="positive" />
           <SnapshotMetric label="Money out" value={moneyOut} tone="critical" />
         </Flex>
@@ -681,7 +691,12 @@ function IntegrationsCard({
                 }
               }}
             >
-              <Flex align="center" justify="space-between" gap={3} wrap="wrap">
+              <Flex
+                align="center"
+                justify="space-between"
+                gap={3}
+                style={{flexWrap: 'wrap'}}
+              >
                 <Stack space={1}>
                   <Text weight="semibold">{integration.name}</Text>
                   <Text size={1} muted>{integration.detail}</Text>
@@ -766,7 +781,7 @@ function OrdersIntegrationSection({
       onBack={onBack}
     >
       <Stack space={5}>
-        <Flex gap={3} wrap="wrap">
+        <Flex gap={3} style={{flexWrap: 'wrap'}}>
           <DetailStatCard
             label="Orders analysed"
             value={number(ordersInRange.length)}
@@ -781,7 +796,7 @@ function OrdersIntegrationSection({
           />
         </Flex>
 
-        <Flex gap={3} wrap="wrap">
+        <Flex gap={3} style={{flexWrap: 'wrap'}}>
           <StatusList title="Order status" items={statusBreakdown} />
           <StatusList title="Payment status" items={paymentBreakdown} />
         </Flex>
@@ -794,7 +809,13 @@ function OrdersIntegrationSection({
                 <Text size={1} muted>No orders captured in this range yet.</Text>
               ) : (
                 recentOrders.map((order) => (
-                  <Flex key={order.id} align="center" justify="space-between" gap={3} wrap="wrap">
+                  <Flex
+                    key={order.id}
+                    align="center"
+                    justify="space-between"
+                    gap={3}
+                    style={{flexWrap: 'wrap'}}
+                  >
                     <Stack space={1}>
                       <Text weight="semibold">Order {shortId(order.id)}</Text>
                       <Text size={1} muted>
@@ -854,7 +875,7 @@ function PayoutsIntegrationSection({payouts, onBack}: {payouts: PayoutSummary | 
       onBack={onBack}
     >
       <Stack space={5}>
-        <Flex gap={3} wrap="wrap">
+        <Flex gap={3} style={{flexWrap: 'wrap'}}>
           <DetailStatCard label="Available balance" value={currency(payouts.available)} helper="Ready to pay out" />
           <DetailStatCard label="Pending balance" value={currency(payouts.pending)} helper="Awaiting settlement" />
           <DetailStatCard
@@ -872,7 +893,13 @@ function PayoutsIntegrationSection({payouts, onBack}: {payouts: PayoutSummary | 
                 <Text size={1} muted>No payouts recorded yet.</Text>
               ) : (
                 recent.map((payout) => (
-                  <Flex key={payout.id} align="center" justify="space-between" gap={3} wrap="wrap">
+                  <Flex
+                    key={payout.id}
+                    align="center"
+                    justify="space-between"
+                    gap={3}
+                    style={{flexWrap: 'wrap'}}
+                  >
                     <Stack space={1}>
                       <Text weight="semibold">{currency(payout.amount)}</Text>
                       <Text size={1} muted>
@@ -932,7 +959,7 @@ function AnalyticsIntegrationSection({
       onBack={onBack}
     >
       <Stack space={5}>
-        <Flex gap={3} wrap="wrap">
+        <Flex gap={3} style={{flexWrap: 'wrap'}}>
           <DetailStatCard label="Visitors" value={number(traffic.visitors)} helper={`${rangeLabel} window`} />
           <DetailStatCard label="Sessions" value={number(traffic.sessions)} helper="Unique sessions" />
           <DetailStatCard label="Pageviews" value={number(traffic.pageviews)} helper="Total views" />
@@ -961,9 +988,15 @@ function AnalyticsIntegrationSection({
                 <Text size={1} muted>No recent analytics samples available.</Text>
               ) : (
                 traffic.recentDaily.map((day) => (
-                  <Flex key={day.date} align="center" justify="space-between" gap={3} wrap="wrap">
+                  <Flex
+                    key={day.date}
+                    align="center"
+                    justify="space-between"
+                    gap={3}
+                    style={{flexWrap: 'wrap'}}
+                  >
                     <Text weight="semibold">{format(new Date(day.date), 'EEE, MMM d')}</Text>
-                    <Flex gap={3} wrap="wrap">
+                    <Flex gap={3} style={{flexWrap: 'wrap'}}>
                       <Badge tone="primary">{number(day.visitors)} visitors</Badge>
                       <Badge tone="default">{number(day.sessions)} sessions</Badge>
                       <Badge tone="default">{number(day.pageviews)} views</Badge>
@@ -993,7 +1026,12 @@ function IntegrationShell({
   return (
     <Card padding={[4, 5]} radius={4} shadow={1} style={{background: 'var(--studio-surface-strong)'}}>
       <Stack space={4}>
-        <Flex align="center" justify="space-between" wrap="wrap" gap={3}>
+        <Flex
+          align="center"
+          justify="space-between"
+          gap={3}
+          style={{flexWrap: 'wrap'}}
+        >
           <Stack space={1}>
             <Heading size={3}>{title}</Heading>
             <Text size={1} muted>{description}</Text>
@@ -1098,7 +1136,7 @@ function AccountsReceivableCard({summary}: {summary: Summary}) {
           <Text size={1} muted>As of today</Text>
         </Flex>
 
-        <Flex align="center" gap={4} wrap="wrap">
+        <Flex align="center" gap={4} style={{flexWrap: 'wrap'}}>
           <DonutChart size={140} thickness={28} segments={segments} total={total}>
             <Flex direction="column" align="center" gap={1}>
               <Text size={1} muted>Total AR</Text>

--- a/packages/sanity-config/src/components/studio/FinancialReports.tsx
+++ b/packages/sanity-config/src/components/studio/FinancialReports.tsx
@@ -111,7 +111,7 @@ export default function FinancialReports() {
       </Box>
 
       {/* Row 1 */}
-      <Flex gap={4} wrap="wrap" marginBottom={4}>
+      <Flex gap={4} marginBottom={4} style={{flexWrap: 'wrap'}}>
         <Box flex={1}>
           <Box marginBottom={2}><Text size={1}>Report Type</Text></Box>
           <Select value={reportType} onChange={e => setReportType((e.target as HTMLSelectElement).value)}>
@@ -131,7 +131,7 @@ export default function FinancialReports() {
       </Flex>
 
       {/* Row 2 */}
-      <Flex gap={4} wrap="wrap" marginBottom={4}>
+      <Flex gap={4} marginBottom={4} style={{flexWrap: 'wrap'}}>
         <Box flex={1}>
           <Box marginBottom={2}><Text size={1}>Status</Text></Box>
           <Select value={status} onChange={e => setStatus((e.target as HTMLSelectElement).value)}>

--- a/packages/sanity-config/src/components/studio/OrderDetailView.tsx
+++ b/packages/sanity-config/src/components/studio/OrderDetailView.tsx
@@ -953,10 +953,15 @@ function OrderDetailView(props: DocumentViewProps) {
     <Box padding={4} style={{backgroundColor: '#f3f4f6', height: '100%', overflow: 'auto'}}>
       <Stack space={4}>
         <Card padding={4} radius={4} shadow={1} style={{backgroundColor: '#ffffff'}}>
-          <Flex align={['stretch', 'center']} justify="space-between" wrap="wrap" gap={4}>
+          <Flex
+            align={['stretch', 'center']}
+            justify="space-between"
+            gap={4}
+            style={{flexWrap: 'wrap'}}
+          >
             <Stack space={3} style={{minWidth: '260px'}}>
               <Heading size={3}>{headerTitle}</Heading>
-              <Flex gap={2} wrap="wrap">
+              <Flex gap={2} style={{flexWrap: 'wrap'}}>
                 {statusBadges.map((badge) => (
                   <SummaryToken key={badge.label} tone={badge.tone}>
                     {badge.label}
@@ -977,7 +982,7 @@ function OrderDetailView(props: DocumentViewProps) {
                 )}
               </Stack>
             </Stack>
-            <Flex gap={3} align="center" wrap="wrap">
+            <Flex gap={3} align="center" style={{flexWrap: 'wrap'}}>
               {refreshing && (
                 <Flex align="center" gap={2}>
                   <Spinner muted />
@@ -1222,7 +1227,7 @@ function OrderDetailView(props: DocumentViewProps) {
                         </Text>
                       )}
                       {item.metaLabels.length > 0 && (
-                        <Flex gap={2} wrap="wrap">
+                        <Flex gap={2} style={{flexWrap: 'wrap'}}>
                           {item.metaLabels.map((meta) => (
                             <SummaryToken key={meta}>{meta}</SummaryToken>
                           ))}

--- a/packages/sanity-config/src/components/studio/OrdersDashboard.tsx
+++ b/packages/sanity-config/src/components/studio/OrdersDashboard.tsx
@@ -795,8 +795,8 @@ export default function OrdersDashboard() {
     <Flex height="fill">
       <Box padding={4} style={{flex: '1 1 auto', overflow: 'auto'}}>
         <Stack space={5}>
-          <Flex wrap="wrap" gap={4} justify="space-between" align="center">
-            <Flex gap={4} align="center" wrap="wrap">
+          <Flex gap={4} justify="space-between" align="center" style={{flexWrap: 'wrap'}}>
+            <Flex gap={4} align="center" style={{flexWrap: 'wrap'}}>
               <Flex direction="column" style={{minWidth: 220}}>
                 <Text size={1} muted>
                   Location
@@ -823,7 +823,7 @@ export default function OrdersDashboard() {
                 </Select>
               </Flex>
             </Flex>
-            <Flex gap={2} align="center" wrap="wrap">
+            <Flex gap={2} align="center" style={{flexWrap: 'wrap'}}>
               <Button text="Export" mode="ghost" disabled={filteredOrders.length === 0} />
               <MenuButton
                 id="orders-dashboard-more-actions"
@@ -915,8 +915,8 @@ export default function OrdersDashboard() {
             </Card>
           </Grid>
 
-          <Flex wrap="wrap" gap={3} align="center" justify="space-between">
-            <Flex gap={2} wrap="wrap">
+          <Flex gap={3} align="center" justify="space-between" style={{flexWrap: 'wrap'}}>
+            <Flex gap={2} style={{flexWrap: 'wrap'}}>
               {tabDefinitions.map(({key, label}) => (
                 <Button
                   key={key}
@@ -927,7 +927,7 @@ export default function OrdersDashboard() {
                 />
               ))}
             </Flex>
-            <Flex gap={3} align="center" wrap="wrap">
+            <Flex gap={3} align="center" style={{flexWrap: 'wrap'}}>
               <Box style={{minWidth: 240}}>
                 <TextInput
                   value={search}
@@ -1081,7 +1081,7 @@ export default function OrdersDashboard() {
                             —
                           </Text>
                         ) : (
-                          <Flex gap={2} wrap="wrap">
+                          <Flex gap={2} style={{flexWrap: 'wrap'}}>
                             {order.tags.map((tag) => (
                               <Badge key={tag} mode="outline">
                                 {tag}
@@ -1429,7 +1429,7 @@ function OrderPreviewPane({orderId, onOpenDocument}: OrderPreviewPaneProps) {
                     {headerTitle}
                   </Text>
                 </Stack>
-                <Flex gap={2} wrap="wrap">
+                <Flex gap={2} style={{flexWrap: 'wrap'}}>
                   {statusBadges.map((badge) => (
                     <Badge key={badge.label} tone={badge.tone} padding={2} mode="outline">
                       {badge.label}
@@ -1448,11 +1448,7 @@ function OrderPreviewPane({orderId, onOpenDocument}: OrderPreviewPaneProps) {
                     </Text>
                   )}
                 </Stack>
-                <Flex
-                  gap={8}
-                  wrap="wrap"
-                  style={{width: '100%'}}
-                >
+                <Flex gap={8} style={{width: '100%', flexWrap: 'wrap'}}>
                   <Button
                     text="Open order"
                     tone="primary"

--- a/packages/sanity-config/src/components/studio/ProductBulkEditor.tsx
+++ b/packages/sanity-config/src/components/studio/ProductBulkEditor.tsx
@@ -1001,7 +1001,7 @@ export default function ProductBulkEditor() {
   return (
     <Card padding={4} radius={3} shadow={1} style={{background: '#0d1117'}}>
       <Stack space={4}>
-        <Flex align="center" justify="space-between" wrap="wrap" gap={3}>
+        <Flex align="center" justify="space-between" gap={3} style={{flexWrap: 'wrap'}}>
           <Box>
             <Text size={2} weight="semibold" style={{color: '#fff'}}>
               Product Bulk Editor

--- a/packages/sanity-config/src/components/studio/ProductListDashboard.tsx
+++ b/packages/sanity-config/src/components/studio/ProductListDashboard.tsx
@@ -963,7 +963,12 @@ const ProductListDashboard = forwardRef<HTMLDivElement | null, Record<string, ne
       />
       <Box padding={5} style={{flex: '1 1 auto', overflow: 'auto'}}>
         <Stack space={5}>
-          <Flex align="flex-start" justify="space-between" wrap="wrap" gap={4}>
+          <Flex
+            align="flex-start"
+            justify="space-between"
+            gap={4}
+            style={{flexWrap: 'wrap'}}
+          >
             <Stack space={3} style={{minWidth: 240}}>
               <Text size={1} muted>
                 Catalog
@@ -975,7 +980,7 @@ const ProductListDashboard = forwardRef<HTMLDivElement | null, Record<string, ne
                 Monitor inventory health, sales readiness, and merchandising coverage across all channels.
               </Text>
             </Stack>
-            <Flex gap={2} align="center" wrap="wrap">
+            <Flex gap={2} align="center" style={{flexWrap: 'wrap'}}>
               <Button
                 text="Export"
                 mode="ghost"
@@ -1019,8 +1024,12 @@ const ProductListDashboard = forwardRef<HTMLDivElement | null, Record<string, ne
 
           <Card padding={4} radius={4} shadow={1} tone="transparent" style={{border: '1px solid var(--card-border-color)'}}>
             <Stack space={4}>
-              <Flex align="center" justify="space-between" wrap="wrap" gap={3}>
-                <Flex align="center" gap={3} wrap="wrap" style={{flex: '1 1 480px'}}>
+              <Flex align="center" justify="space-between" gap={3} style={{flexWrap: 'wrap'}}>
+                <Flex
+                  align="center"
+                  gap={3}
+                  style={{flexWrap: 'wrap', flex: '1 1 480px'}}
+                >
                   <Box style={{flex: '1 1 280px', minWidth: 240}}>
                     <TextInput
                       value={searchTerm}
@@ -1106,7 +1115,7 @@ const ProductListDashboard = forwardRef<HTMLDivElement | null, Record<string, ne
                     }
                   />
                 </Flex>
-                <Flex align="center" gap={2} wrap="wrap">
+                <Flex align="center" gap={2} style={{flexWrap: 'wrap'}}>
                   <MenuButton
                     id="product-saved-views"
                     button={<Button text="Saved views" mode="ghost" />}
@@ -1118,7 +1127,7 @@ const ProductListDashboard = forwardRef<HTMLDivElement | null, Record<string, ne
               </Flex>
 
               {activeFilters && (
-                <Flex gap={2} wrap="wrap">
+                <Flex gap={2} style={{flexWrap: 'wrap'}}>
                   {Array.from(vendorFilters).map((vendor) => (
                     <Card key={`vendor-${vendor}`} paddingX={2} paddingY={1} tone="primary" radius={3} border>
                       <Flex align="center" gap={2}>

--- a/packages/sanity-config/src/components/studio/SalesTransactions.tsx
+++ b/packages/sanity-config/src/components/studio/SalesTransactions.tsx
@@ -328,7 +328,7 @@ export default function SalesTransactions() {
           )}
 
           <Card padding={3} radius={3} shadow={1}>
-            <Flex wrap="wrap" gap={3}>
+            <Flex gap={3} style={{flexWrap: 'wrap'}}>
               <Flex direction="column" style={{ minWidth: 200 }}>
                 <Text size={1} muted>
                   Type


### PR DESCRIPTION
## Summary
- replace uses of the `wrap` prop on Sanity `Flex` components with inline `flexWrap` styles across studio dashboard views
- ensure existing layout-specific styles are preserved while preventing invalid DOM attributes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb36c27784832cb6bc37930d60adef