### PR TITLE
fix: patch sanity ui refractor import (follow-up)

### DIFF
--- a/packages/sanity-config/tailwind.config.cjs
+++ b/packages/sanity-config/tailwind.config.cjs
@@ -1,11 +1,11 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    './index.html',
-    './sanity.config.ts',
-    './src/components/**/*.{js,jsx,ts,tsx}',
-    './src/schemaTypes/**/*.{js,jsx,ts,tsx}',
-    './src/**/*.{js,jsx,ts,tsx}',
+    './packages/sanity-config/index.html',
+    './packages/sanity-config/sanity.config.ts',
+    './packages/sanity-config/src/components/**/*.{js,jsx,ts,tsx}',
+    './packages/sanity-config/src/schemaTypes/**/*.{js,jsx,ts,tsx}',
+    './packages/sanity-config/src/**/*.{js,jsx,ts,tsx}',
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- point the Tailwind content globs at the packages/sanity-config sources so scanning still works from the workspace root

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68fba74aaaec832c99cfc767a325e2c3