### PR TITLE
Add preview URL secret dependency to Sanity config

### DIFF
--- a/packages/sanity-config/package.json
+++ b/packages/sanity-config/package.json
@@ -19,6 +19,7 @@
     "@sanity/code-input": "latest",
     "@sanity/icons": "latest",
     "@sanity/presentation": "^1.9.1",
+    "@sanity/preview-url-secret": "^2.1.15",
     "@sanity/ui": "latest",
     "@sanity/vision": "latest",
     "@stripe/stripe-js": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       '@sanity/presentation':
         specifier: ^1.9.1
         version: 1.22.1(@emotion/is-prop-valid@1.4.0)(@sanity/types@4.11.0(@types/react@18.3.24))(react-dom@18.3.1(react@18.3.1))(react-is@19.1.1)(react@18.3.1)(sanity@4.11.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.1.15(@sanity/schema@4.11.0(@types/react@18.3.24))(@sanity/types@4.11.0(@types/react@18.3.24)))(@types/node@22.18.12)(@types/react@18.3.24)(canvas@2.11.2)(immer@10.1.3)(jiti@2.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@sanity/preview-url-secret':
+        specifier: ^2.1.15
+        version: 2.1.15(@sanity/client@7.12.0)(@sanity/icons@3.7.4(react@18.3.1))(sanity@4.11.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.1.15(@sanity/schema@4.11.0(@types/react@18.3.24))(@sanity/types@4.11.0(@types/react@18.3.24)))(@types/node@22.18.12)(@types/react@18.3.24)(canvas@2.11.2)(immer@10.1.3)(jiti@2.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))
       '@sanity/ui':
         specifier: latest
         version: 3.1.11(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-is@19.1.1)(react@18.3.1)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))


### PR DESCRIPTION
## Summary
- add @sanity/preview-url-secret to the Sanity workspace dependencies to satisfy Vite bundling
- update the lockfile to record the new dependency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbe75c32f8832cabe368ba78848917