### PR TITLE
feat: enhance customer previews and document lists

### DIFF
--- a/packages/sanity-config/src/components/previews/CustomerAvatarStack.tsx
+++ b/packages/sanity-config/src/components/previews/CustomerAvatarStack.tsx
@@ -1,0 +1,168 @@
+import React, {useEffect, useMemo, useState} from 'react'
+import {useClient} from 'sanity'
+
+const FALLBACK_IMAGE =
+  'https://cdn.sanity.io/images/r4og35qd/production/c3623df3c0e45a480c59d12765725f985f6d2fdb-1000x1000.png?fit=max&w=500&h=500'
+
+const ORDER_ITEMS_QUERY = `
+  *[_type == "order" && customerRef._ref == $customerId]
+    | order(createdAt desc)[0...5].cart[]{
+      "imageUrl": coalesce(productImage.asset->url, image.asset->url),
+      "productRef": coalesce(productRef._ref, product._ref),
+      "productSlug": coalesce(productSlug, slug.current, id)
+    }
+`
+
+const PRODUCT_IMAGES_QUERY = `
+  *[_type == "product" && (
+      defined($ids[0]) && _id in $ids || defined($slugs[0]) && slug.current in $slugs
+    )]{
+      _id,
+      "slug": slug.current,
+      "imageUrl": coalesce(
+        defaultProductVariant.images[0].asset->url,
+        images[0].asset->url
+      )
+    }
+`
+
+type OrderItemPreview = {
+  imageUrl?: string | null
+  productRef?: string | null
+  productSlug?: string | null
+}
+
+type ProductPreview = {
+  _id: string
+  slug?: string
+  imageUrl?: string | null
+}
+
+interface CustomerAvatarStackProps {
+  customerId?: string
+}
+
+export function CustomerAvatarStack({customerId}: CustomerAvatarStackProps) {
+  const client = useClient({apiVersion: '2024-10-01'})
+  const [images, setImages] = useState<string[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      if (!customerId) {
+        if (!cancelled) setImages([])
+        return
+      }
+
+      try {
+        const orderItems: OrderItemPreview[] = await client.fetch(ORDER_ITEMS_QUERY, {customerId})
+
+        if (cancelled) return
+
+        const directImages = orderItems
+          .map((item) => item.imageUrl)
+          .filter((url): url is string => typeof url === 'string' && url.length > 0)
+
+        const neededRefs = Array.from(
+          new Set(
+            orderItems
+              .map((item) => item.productRef)
+              .filter((ref): ref is string => typeof ref === 'string' && ref.length > 0)
+          )
+        )
+
+        const neededSlugs = Array.from(
+          new Set(
+            orderItems
+              .map((item) => item.productSlug)
+              .filter((slug): slug is string => typeof slug === 'string' && slug.length > 0)
+          )
+        )
+
+        let productLookups: ProductPreview[] = []
+        if ((neededRefs.length > 0 || neededSlugs.length > 0) && (!directImages || directImages.length < 3)) {
+          productLookups = await client.fetch(PRODUCT_IMAGES_QUERY, {
+            ids: neededRefs,
+            slugs: neededSlugs,
+          })
+        }
+
+        if (cancelled) return
+
+        const imageByKey = new Map<string, string>()
+        for (const product of productLookups) {
+          if (product.imageUrl) {
+            imageByKey.set(product._id, product.imageUrl)
+            if (product.slug) {
+              imageByKey.set(product.slug, product.imageUrl)
+            }
+          }
+        }
+
+        const collected: string[] = []
+        const pushUnique = (url?: string | null) => {
+          if (!url) return
+          if (collected.includes(url)) return
+          collected.push(url)
+        }
+
+        directImages.forEach((url) => pushUnique(url))
+
+        if (collected.length < 3) {
+          for (const item of orderItems) {
+            if (collected.length >= 3) break
+            const byRef = item.productRef ? imageByKey.get(item.productRef) : undefined
+            const bySlug = item.productSlug ? imageByKey.get(item.productSlug) : undefined
+            pushUnique(byRef || bySlug)
+          }
+        }
+
+        setImages(collected.slice(0, 3))
+      } catch (err) {
+        console.warn('Unable to load customer product previews', err)
+        if (!cancelled) setImages([])
+      }
+    }
+
+    load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [client, customerId])
+
+  const imageUrls = useMemo(() => {
+    if (images.length > 0) {
+      return images
+    }
+    return [FALLBACK_IMAGE]
+  }, [images])
+
+  return (
+    <div style={{display: 'flex', alignItems: 'center', height: '100%'}}>
+      {imageUrls.slice(0, 3).map((url, index) => (
+        <span
+          key={`${url}-${index}`}
+          style={{
+            position: 'relative',
+            width: 36,
+            height: 36,
+            borderRadius: '50%',
+            overflow: 'hidden',
+            border: '2px solid var(--card-bg, #fff)',
+            boxShadow: '0 0 0 1px rgba(0,0,0,0.08)',
+            marginLeft: index === 0 ? 0 : -12,
+            backgroundColor: '#f5f5f5',
+          }}
+        >
+          <img
+            src={url}
+            alt={index === 0 ? 'Ordered product preview' : 'Additional ordered product'}
+            style={{width: '100%', height: '100%', objectFit: 'cover'}}
+          />
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/packages/sanity-config/src/desk/deskStructure.ts
+++ b/packages/sanity-config/src/desk/deskStructure.ts
@@ -21,6 +21,7 @@ const productsByCategory = (S: any) =>
     .title('Products by category')
     .child(
       S.documentTypeList('category')
+        .apiVersion('2024-10-01')
         .title('Categories')
         .child((categoryId: string) =>
           S.documentList()
@@ -57,8 +58,8 @@ export const deskStructure: StructureResolver = (S) =>
                 .title('All customers')
                 .child(
                   S.documentTypeList('customer')
-                    .title('All customers')
                     .apiVersion('2024-10-01')
+                    .title('All customers')
                     .filter('_type == "customer"')
                     .defaultOrdering([
                       {field: 'lifetimeSpend', direction: 'desc'},

--- a/packages/sanity-config/src/deskStructure.ts
+++ b/packages/sanity-config/src/deskStructure.ts
@@ -18,7 +18,11 @@ export const deskStructure: StructureResolver = (S, context) => {
           .id(`mgr-${typeName}`)
           .title(title)
           .icon(icon)
-          .child(S.documentTypeList(typeName).title(title))
+          .child(
+            S.documentTypeList(typeName)
+              .apiVersion('2024-10-01')
+              .title(title)
+          )
       : S.listItem()
           .id(`missing-${typeName}`)
           .title(`Missing: ${typeName} schema`)

--- a/packages/sanity-config/src/schemaTypes/documents/customer.tsx
+++ b/packages/sanity-config/src/schemaTypes/documents/customer.tsx
@@ -1,0 +1,168 @@
+
+import React from 'react'
+import { defineType, defineField } from 'sanity'
+import {CustomerAvatarStack} from '../../components/previews/CustomerAvatarStack'
+
+export default defineType({
+  name: 'customer',
+  title: 'Customer',
+  type: 'document',
+  fieldsets: [
+    {
+      name: 'shippingInfo',
+      title: 'Shipping Address',
+      options: { collapsible: true, collapsed: true },
+    },
+    {
+      name: 'billingInfo',
+      title: 'Billing Address',
+      options: { collapsible: true, collapsed: true },
+    },
+  ],
+  fields: [
+    // Identity
+    defineField({
+      name: 'userId',
+      title: 'External User ID',
+      type: 'string',
+      description:
+        'Legacy identifier for imported accounts. FAS Auth uses this document ID, so new users can leave this empty.',
+    }),
+    defineField({
+      name: 'name',
+      title: 'Legacy Full Name',
+      type: 'string',
+      readOnly: true,
+      description:
+        'Existing records may still use this legacy field. Use the action button or copy the value into First/Last Name below.',
+      hidden: ({ document }) => !document?.name,
+    }),
+    defineField({ name: 'firstName', title: 'First Name', type: 'string' }),
+    defineField({ name: 'lastName', title: 'Last Name', type: 'string' }),
+    defineField({
+      name: 'email',
+      title: 'Email',
+      type: 'string',
+      validation: Rule => Rule.required().email()
+    }),
+    defineField({
+      name: 'stripeCustomerId',
+      title: 'Stripe Customer ID',
+      type: 'string',
+      readOnly: true,
+    }),
+    defineField({
+      name: 'stripeLastSyncedAt',
+      title: 'Stripe Last Synced',
+      type: 'datetime',
+      readOnly: true,
+    }),
+    defineField({
+      name: 'roles',
+      title: 'Roles',
+      type: 'array',
+      of: [{ type: 'string' }],
+      initialValue: ['customer'],
+      options: {
+        list: [
+          { title: 'Customer', value: 'customer' },
+          { title: 'Guest (no account)', value: 'guest' },
+          { title: 'Vendor', value: 'vendor' },
+          { title: 'Admin', value: 'admin' },
+        ],
+      },
+      validation: (Rule) => Rule.required().min(1).warning('Users should have at least one role'),
+      description:
+        'Used by FAS Auth to gate access to portals. Guests are imported from Stripe and do not have login access.',
+    }),
+    defineField({
+      name: 'passwordHash',
+      title: 'Password Hash',
+      type: 'string',
+      hidden: true
+    }),
+    defineField({ name: 'phone', title: 'Phone Number', type: 'string' }),
+    defineField({
+      name: 'shippingAddress',
+      title: 'Shipping Address',
+      type: 'customerBillingAddress',
+      fieldset: 'shippingInfo',
+    }),
+    defineField({
+      name: 'address',
+      title: 'Shipping Address (legacy)',
+      type: 'text',
+      fieldset: 'shippingInfo',
+      hidden: true,
+    }),
+    defineField({
+      name: 'billingAddress',
+      title: 'Billing Address',
+      type: 'customerBillingAddress',
+      fieldset: 'billingInfo',
+    }),
+    defineField({ name: 'orders', title: 'Orders', type: 'array', of: [ { type: 'customerOrderSummary' } ] }),
+    defineField({ name: 'quotes', title: 'Saved Quotes', type: 'array', of: [ { type: 'customerQuoteSummary' } ] }),
+    defineField({ name: 'addresses', title: 'Addresses', type: 'array', of: [ { type: 'customerAddress' } ] }),
+    defineField({
+      name: 'wishlistItems',
+      title: 'Wishlist Items',
+      type: 'array',
+      of: [{ type: 'reference', to: [{ type: 'product' }] }]
+    }),
+    defineField({
+      name: 'stripeMetadata',
+      title: 'Latest Stripe Metadata',
+      type: 'array',
+      of: [{ type: 'stripeMetadataEntry' }],
+      readOnly: true,
+    }),
+    // Marketing preferences
+    defineField({ name: 'emailOptIn', title: 'Email Opt‑In', type: 'boolean', initialValue: false }),
+    defineField({ name: 'marketingOptIn', title: 'Marketing Opt‑In', type: 'boolean', initialValue: false }),
+    defineField({ name: 'textOptIn', title: 'Text/SMS Opt‑In', type: 'boolean', initialValue: false }),
+    defineField({ name: 'orderCount', title: 'Order Count', type: 'number', readOnly: true }),
+    defineField({ name: 'quoteCount', title: 'Quote Count', type: 'number', readOnly: true }),
+    defineField({ name: 'lifetimeSpend', title: 'Lifetime Spend ($)', type: 'number', readOnly: true }),
+    defineField({ name: 'updatedAt', title: 'Updated At', type: 'datetime' }),
+  ],
+
+  preview: {
+    select: {
+      _id: '_id',
+      firstName: 'firstName',
+      lastName: 'lastName',
+      email: 'email',
+      orderCount: 'orderCount',
+      lifetimeSpend: 'lifetimeSpend',
+      city: 'shippingAddress.city',
+      state: 'shippingAddress.state',
+      emailOptIn: 'emailOptIn',
+      marketingOptIn: 'marketingOptIn',
+    },
+    prepare({ _id, firstName, lastName, email, orderCount, lifetimeSpend, city, state, emailOptIn, marketingOptIn }) {
+      const name = [firstName, lastName].filter(Boolean).join(' ').trim()
+      const location = [city, state].filter(Boolean).join(', ')
+      const orders = typeof orderCount === 'number' ? orderCount : 0
+      const spend = typeof lifetimeSpend === 'number'
+        ? new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(lifetimeSpend)
+        : '$0'
+      const subscribed = emailOptIn || marketingOptIn ? '✓' : ''
+
+      const parts = [
+        orders > 0 ? `${orders} orders` : 'No orders',
+        spend,
+        location,
+        subscribed ? 'Subscribed' : ''
+      ].filter(Boolean)
+
+      return {
+        title: name || email || 'Unnamed Customer',
+        subtitle: email || undefined,
+        description: parts.join(' • ') || undefined,
+        media: () => <CustomerAvatarStack customerId={_id} />,
+      }
+    },
+  },
+
+})

--- a/packages/sanity-config/src/structure/collectionStructure.ts
+++ b/packages/sanity-config/src/structure/collectionStructure.ts
@@ -2,5 +2,8 @@ import {ListItemBuilder} from 'sanity/structure'
 import defineStructure from '../utils/defineStructure'
 
 export default defineStructure<ListItemBuilder>((S) =>
-  S.listItem().title('Collections').schemaType('collection').child(S.documentTypeList('collection'))
+  S.listItem()
+    .title('Collections')
+    .schemaType('collection')
+    .child(S.documentTypeList('collection').apiVersion('2024-10-01'))
 )

--- a/packages/sanity-config/src/structure/colorThemeStructure.ts
+++ b/packages/sanity-config/src/structure/colorThemeStructure.ts
@@ -5,5 +5,7 @@ export default defineStructure<ListItemBuilder>((S) =>
   S.listItem()
     .title('Color themes')
     .schemaType('colorTheme')
-    .child(S.documentTypeList('colorTheme'))
+    .child(
+      S.documentTypeList('colorTheme').apiVersion('2024-10-01')
+    )
 )

--- a/packages/sanity-config/src/structure/freightQuoteStructure.ts
+++ b/packages/sanity-config/src/structure/freightQuoteStructure.ts
@@ -13,7 +13,11 @@ export default defineStructure<ListItemBuilder>((S) =>
           S.listItem()
             .title('All')
             .schemaType('freightQuote')
-            .child(S.documentTypeList('freightQuote').title('All Freight Quotes')),
+            .child(
+              S.documentTypeList('freightQuote')
+                .apiVersion('2024-10-01')
+                .title('All Freight Quotes')
+            ),
 
           S.listItem()
             .title('Open')

--- a/packages/sanity-config/src/structure/index.ts
+++ b/packages/sanity-config/src/structure/index.ts
@@ -64,6 +64,7 @@ export const structure: StructureResolver = (S, context) =>
         .schemaType('shippingLabel')
         .child(
           S.documentTypeList('shippingLabel')
+            .apiVersion('2024-10-01')
             .title('Shipping Labels')
         ),
       S.divider(),

--- a/packages/sanity-config/src/structure/orderStructure.ts
+++ b/packages/sanity-config/src/structure/orderStructure.ts
@@ -14,7 +14,11 @@ export default defineStructure<ListItemBuilder>((S) =>
           S.listItem()
             .title('All Invoices')
             .schemaType('order')
-            .child(S.documentTypeList('order').title('All Orders')),
+            .child(
+              S.documentTypeList('order')
+                .apiVersion('2024-10-01')
+                .title('All Orders')
+            ),
 
           S.listItem()
             .title('Unfulfilled Orders')

--- a/packages/sanity-config/src/structure/pageStructure.ts
+++ b/packages/sanity-config/src/structure/pageStructure.ts
@@ -7,5 +7,5 @@ export default defineStructure<ListItemBuilder>((S) =>
     .title('Pages')
     .icon(DocumentsIcon)
     .schemaType('page')
-    .child(S.documentTypeList('page'))
+    .child(S.documentTypeList('page').apiVersion('2024-10-01'))
 )

--- a/packages/sanity-config/src/structure/productStructure.ts
+++ b/packages/sanity-config/src/structure/productStructure.ts
@@ -8,6 +8,7 @@ export default defineStructure<ListItemBuilder>((S) =>
     .schemaType('product')
     .child(
       S.documentTypeList('product')
+        .apiVersion('2024-10-01')
         // .defaultLayout('detail')
         .child(async (id) =>
           S.list()
@@ -29,6 +30,7 @@ export default defineStructure<ListItemBuilder>((S) =>
                 .schemaType('productVariant')
                 .child(
                   S.documentList()
+                    .apiVersion('2024-10-01')
                     .title('Variants')
                     .schemaType('productVariant')
                     .filter(


### PR DESCRIPTION
## Summary
- add a reusable `CustomerAvatarStack` preview component that loads recent order product imagery with a logo fallback
- update the customer schema preview to show bold names, email subtitles, and the avatar stack media
- align custom document lists across the desk structure with the 2024-10-01 API version to pick up the latest search/navigation improvements

## Testing
- `pnpm lint` *(fails: existing lint warnings and react hook rule violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68fc5be425ac832c9bc47ce0e22a14b8