### PR TITLE
Fix GROQ filters and harden invoice inputs

### DIFF
--- a/packages/sanity-config/src/desk/deskStructure.ts
+++ b/packages/sanity-config/src/desk/deskStructure.ts
@@ -87,7 +87,7 @@ export const deskStructure: StructureResolver = (S) =>
                     .apiVersion('2024-10-01')
                     .title('Customers with no orders')
                     .schemaType('customer')
-                    .filter('(orderCount ?? 0) == 0')
+                    .filter('coalesce(orderCount, 0) == 0')
                     .defaultOrdering([{field: '_createdAt', direction: 'desc'}])
                 ),
               S.listItem()
@@ -346,7 +346,7 @@ export const deskStructure: StructureResolver = (S) =>
                     .apiVersion('2024-10-01')
                     .title('Out of stock products')
                     .schemaType('product')
-                    .filter('_type == "product" && (inventory.quantity ?? 0) <= 0')
+                    .filter('_type == "product" && coalesce(inventory.quantity, 0) <= 0')
                     .defaultOrdering([{field: 'title', direction: 'asc'}])
                     .child((documentId: string) =>
                       S.document()


### PR DESCRIPTION
## Summary
- replace nullish coalescing in desk filters with `coalesce` so GROQ queries parse correctly
- add a safe `useMaybeFormValue` helper and adopt it across invoice inputs to prevent FormValueProvider runtime errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd16c43d08832caea32b6b6b95af72