### PR TITLE
Fix GROQ projection syntax in HomePane queries

### DIFF
--- a/packages/sanity-config/src/components/studio/HomePane.tsx
+++ b/packages/sanity-config/src/components/studio/HomePane.tsx
@@ -84,7 +84,7 @@ const ORDER_QUERY = `*[_type == "order"] | order(coalesce(createdAt, _createdAt)
   orderNumber,
   customerName,
   totalAmount,
-  coalesce(createdAt, _createdAt) as _createdAt
+  _createdAt: coalesce(createdAt, _createdAt)
 }`
 
 const PRODUCT_QUERY = `*[_type == "product"] | order(_updatedAt desc)[0...5]{
@@ -103,7 +103,7 @@ const INVOICE_QUERY = `*[_type == "invoice"] | order(coalesce(issueDate, _create
   customerName,
   total,
   status,
-  coalesce(issueDate, _createdAt) as _createdAt
+  _createdAt: coalesce(issueDate, _createdAt)
 }`
 
 const formatDate = (value?: string | null) => {


### PR DESCRIPTION
## Summary
- update the HomePane order and invoice queries to use GROQ alias syntax so they parse correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd1e5b5fcc832c86edc60542584099