### PR TITLE
Allow configuring Sanity project and dataset via env

### DIFF
--- a/netlify/functions/autoRelatedProducts.ts
+++ b/netlify/functions/autoRelatedProducts.ts
@@ -11,7 +11,8 @@ import { createClient } from '@sanity/client'
  */
 const projectId = process.env.SANITY_STUDIO_PROJECT_ID || ''
 
-const dataset = process.env.SANITY_STUDIO_DATASET || 'production'
+const dataset =
+  process.env.SANITY_STUDIO_DATASET || process.env.SANITY_DATASET || 'production'
 
 const token = process.env.SANITY_API_TOKEN || ''
 const secret = process.env.SANITY_WEBHOOK_SECRET // optional but recommended

--- a/netlify/functions/backfillCustomers.ts
+++ b/netlify/functions/backfillCustomers.ts
@@ -18,7 +18,8 @@ function makeCORS(origin?: string) {
 
 const SANITY_PROJECT_ID = process.env.SANITY_STUDIO_PROJECT_ID || ''
 
-const SANITY_DATASET = process.env.SANITY_STUDIO_DATASET || 'production'
+const SANITY_DATASET =
+  process.env.SANITY_STUDIO_DATASET || process.env.SANITY_DATASET || 'production'
 
 if (!SANITY_PROJECT_ID) {
   throw new Error('Missing Sanity projectId for backfillCustomers (set SANITY_STUDIO_PROJECT_ID).')

--- a/netlify/functions/backfillOrders.ts
+++ b/netlify/functions/backfillOrders.ts
@@ -35,7 +35,8 @@ function makeCORS(origin?: string) {
 
 const SANITY_PROJECT_ID = process.env.SANITY_STUDIO_PROJECT_ID || ''
 
-const SANITY_DATASET = process.env.SANITY_STUDIO_DATASET || 'production'
+const SANITY_DATASET =
+  process.env.SANITY_STUDIO_DATASET || process.env.SANITY_DATASET || 'production'
 
 if (!SANITY_PROJECT_ID) {
   throw new Error('Missing Sanity projectId for backfillOrders (set SANITY_STUDIO_PROJECT_ID).')

--- a/netlify/functions/finalizeFinancialConnection.ts
+++ b/netlify/functions/finalizeFinancialConnection.ts
@@ -10,9 +10,13 @@ const stripe =
     apiVersion: '2024-06-20' as unknown as Stripe.StripeConfig['apiVersion'],
   })
 
-const projectId = process.env.SANITY_STUDIO_PROJECT_ID || 'r4og35qd'
+const projectId =
+  process.env.SANITY_STUDIO_PROJECT_ID ||
+  process.env.SANITY_PROJECT_ID ||
+  'r4og35qd'
 
-const dataset = process.env.SANITY_STUDIO_DATASET || 'production'
+const dataset =
+  process.env.SANITY_STUDIO_DATASET || process.env.SANITY_DATASET || 'production'
 
 const sanityToken = process.env.SANITY_API_TOKEN
 

--- a/netlify/functions/generateCheckPDF.ts
+++ b/netlify/functions/generateCheckPDF.ts
@@ -5,9 +5,13 @@ import Stripe from 'stripe'
 import fs from 'fs'
 import path from 'path'
 
-const projectId = process.env.SANITY_STUDIO_PROJECT_ID || 'r4og35qd'
+const projectId =
+  process.env.SANITY_STUDIO_PROJECT_ID ||
+  process.env.SANITY_PROJECT_ID ||
+  'r4og35qd'
 
-const dataset = process.env.SANITY_STUDIO_DATASET || 'production'
+const dataset =
+  process.env.SANITY_STUDIO_DATASET || process.env.SANITY_DATASET || 'production'
 
 const sanityToken = process.env.SANITY_API_TOKEN
 

--- a/netlify/functions/generateQuotePDF.ts
+++ b/netlify/functions/generateQuotePDF.ts
@@ -12,8 +12,14 @@ const CORS = {
 }
 
 const sanity = createClient({
-  projectId: process.env.SANITY_STUDIO_PROJECT_ID || 'r4og35qd',
-  dataset: process.env.SANITY_STUDIO_DATASET || 'production',
+  projectId:
+    process.env.SANITY_STUDIO_PROJECT_ID ||
+    process.env.SANITY_PROJECT_ID ||
+    'r4og35qd',
+  dataset:
+    process.env.SANITY_STUDIO_DATASET ||
+    process.env.SANITY_DATASET ||
+    'production',
   apiVersion: '2024-04-10',
   token: process.env.SANITY_API_TOKEN || undefined, // optional; read works without in public datasets
   useCdn: false,

--- a/netlify/functions/sendQuoteEmail.ts
+++ b/netlify/functions/sendQuoteEmail.ts
@@ -7,8 +7,14 @@ const resend = new Resend(process.env.RESEND_API_KEY)
 
 // Prefer the single write token you set up; no fallback to PUBLIC_*
 const sanity = createClient({
-  projectId: process.env.SANITY_STUDIO_PROJECT_ID || 'r4og35qd',
-  dataset: process.env.SANITY_STUDIO_DATASET || 'production',
+  projectId:
+    process.env.SANITY_STUDIO_PROJECT_ID ||
+    process.env.SANITY_PROJECT_ID ||
+    'r4og35qd',
+  dataset:
+    process.env.SANITY_STUDIO_DATASET ||
+    process.env.SANITY_DATASET ||
+    'production',
   apiVersion: '2024-04-10',
   useCdn: false,
   token: process.env.SANITY_API_TOKEN,

--- a/netlify/functions/syncMerchantProducts.ts
+++ b/netlify/functions/syncMerchantProducts.ts
@@ -4,8 +4,14 @@ import {google} from 'googleapis'
 import {deriveProductFeedFields} from '../../packages/sanity-config/src/utils/productFeed'
 
 const sanity = createClient({
-  projectId: process.env.SANITY_STUDIO_PROJECT_ID || 'r4og35qd',
-  dataset: process.env.SANITY_STUDIO_DATASET || 'production',
+  projectId:
+    process.env.SANITY_STUDIO_PROJECT_ID ||
+    process.env.SANITY_PROJECT_ID ||
+    'r4og35qd',
+  dataset:
+    process.env.SANITY_STUDIO_DATASET ||
+    process.env.SANITY_DATASET ||
+    'production',
   apiVersion: '2024-04-10',
   useCdn: false,
   token: process.env.SANITY_API_TOKEN,

--- a/netlify/functions/syncStripeCatalog.ts
+++ b/netlify/functions/syncStripeCatalog.ts
@@ -19,7 +19,8 @@ const stripe = stripeSecret ? new Stripe(stripeSecret) : null
 
 const SANITY_PROJECT_ID = process.env.SANITY_STUDIO_PROJECT_ID || ''
 
-const SANITY_DATASET = process.env.SANITY_STUDIO_DATASET || 'production'
+const SANITY_DATASET =
+  process.env.SANITY_STUDIO_DATASET || process.env.SANITY_DATASET || 'production'
 
 if (!SANITY_PROJECT_ID) {
   throw new Error('syncStripeCatalog: missing Sanity project id (set SANITY_STUDIO_PROJECT_ID).')

--- a/packages/hydrogen-sanity/src/lib/api/create-shipping-label.ts
+++ b/packages/hydrogen-sanity/src/lib/api/create-shipping-label.ts
@@ -40,8 +40,18 @@ export interface CreateLabelResult {
 
 // ---- Sanity client (serverless endpoints should do the logging, but keep as fallback) ----
 const sanityClient = createClient({
-  projectId: 'r4og35qd',
-  dataset: 'production',
+  projectId:
+    process.env.NEXT_PUBLIC_SANITY_PROJECT_ID ||
+    process.env.VITE_SANITY_STUDIO_PROJECT_ID ||
+    process.env.SANITY_STUDIO_PROJECT_ID ||
+    process.env.SANITY_PROJECT_ID ||
+    'r4og35qd',
+  dataset:
+    process.env.NEXT_PUBLIC_SANITY_DATASET ||
+    process.env.VITE_SANITY_STUDIO_DATASET ||
+    process.env.SANITY_STUDIO_DATASET ||
+    process.env.SANITY_DATASET ||
+    'production',
   token: process.env.SANITY_API_TOKEN,
   apiVersion: '2023-01-01',
   useCdn: false,

--- a/packages/sanity-config/sanity.cli.ts
+++ b/packages/sanity-config/sanity.cli.ts
@@ -2,8 +2,14 @@ import {defineCliConfig} from 'sanity/cli'
 
 export default defineCliConfig({
   api: {
-    projectId: 'r4og35qd',
-    dataset: 'production',
+    projectId:
+      process.env.SANITY_STUDIO_PROJECT_ID ||
+      process.env.SANITY_PROJECT_ID ||
+      'r4og35qd',
+    dataset:
+      process.env.SANITY_STUDIO_DATASET ||
+      process.env.SANITY_DATASET ||
+      'production',
   },
   server: {
     hostname: 'localhost',

--- a/packages/sanity-config/sanity.config.ts
+++ b/packages/sanity-config/sanity.config.ts
@@ -187,8 +187,14 @@ export default defineConfig({
   name: 'default',
   title: 'FAS Motorsports',
 
-  projectId: process.env.SANITY_STUDIO_PROJECT_ID || 'r4og35qd',
-  dataset: process.env.SANITY_STUDIO_DATASET || 'production',
+  projectId:
+    process.env.SANITY_STUDIO_PROJECT_ID ||
+    process.env.SANITY_PROJECT_ID ||
+    'r4og35qd',
+  dataset:
+    process.env.SANITY_STUDIO_DATASET ||
+    process.env.SANITY_DATASET ||
+    'production',
   /**
    * CORS origins must include:
    *   http://localhost:8888

--- a/packages/sanity-config/src/utils/useWorkspaceClient.ts
+++ b/packages/sanity-config/src/utils/useWorkspaceClient.ts
@@ -5,8 +5,12 @@ import {WorkspaceContext} from 'sanity/_singletons'
 
 type UseClientOptions = Parameters<typeof useClient>[0]
 
-const DEFAULT_PROJECT_ID = process.env.SANITY_STUDIO_PROJECT_ID || 'r4og35qd'
-const DEFAULT_DATASET = process.env.SANITY_STUDIO_DATASET || 'production'
+const DEFAULT_PROJECT_ID =
+  process.env.SANITY_STUDIO_PROJECT_ID ||
+  process.env.SANITY_PROJECT_ID ||
+  'r4og35qd'
+const DEFAULT_DATASET =
+  process.env.SANITY_STUDIO_DATASET || process.env.SANITY_DATASET || 'production'
 const FALLBACK_API_VERSION = '2024-10-01'
 
 function useOptionalStudioClient(options?: UseClientOptions) {

--- a/scripts/ensure-sanity-cors.ts
+++ b/scripts/ensure-sanity-cors.ts
@@ -1,7 +1,10 @@
 import 'dotenv/config'
 import fetch from 'node-fetch'
 
-const projectId = process.env.SANITY_STUDIO_PROJECT_ID || 'r4og35qd'
+const projectId =
+  process.env.SANITY_STUDIO_PROJECT_ID ||
+  process.env.SANITY_PROJECT_ID ||
+  'r4og35qd'
 const token =
   process.env.SANITY_API_TOKEN ||
   process.env.SANITY_AUTH_TOKEN ||

--- a/scripts/upload-google-merchant-sftp.ts
+++ b/scripts/upload-google-merchant-sftp.ts
@@ -92,7 +92,9 @@ function assertEnv() {
 }
 
 const SANITY_PROJECT_ID =
-  process.env.SANITY_STUDIO_PROJECT_ID || process.env.SANITY_PROJECT_ID || 'r4og35qd'
+  process.env.SANITY_STUDIO_PROJECT_ID ||
+  process.env.SANITY_PROJECT_ID ||
+  'r4og35qd'
 const SANITY_DATASET =
   process.env.SANITY_STUDIO_DATASET || process.env.SANITY_DATASET || 'production'
 


### PR DESCRIPTION
## Summary
- extend Sanity project and dataset resolution to read SANITY_PROJECT_ID/SANITY_DATASET when studio-specific vars are missing
- update Netlify functions and helper scripts to respect the expanded environment fallbacks
- ensure Hydrogen helpers use the shared fallback resolution for server-side logging

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68fd1f629dfc832c9d87e7cc58a738f0