### PR TITLE
Fix GROQ aliases in HomePane queries

### DIFF
--- a/packages/sanity-config/src/components/studio/HomePane.tsx
+++ b/packages/sanity-config/src/components/studio/HomePane.tsx
@@ -84,7 +84,7 @@ const ORDER_QUERY = `*[_type == "order"] | order(coalesce(createdAt, _createdAt)
   orderNumber,
   customerName,
   totalAmount,
-  _createdAt: coalesce(createdAt, _createdAt)
+  "_createdAt": coalesce(createdAt, _createdAt)
 }`
 
 const PRODUCT_QUERY = `*[_type == "product"] | order(_updatedAt desc)[0...5]{
@@ -103,7 +103,7 @@ const INVOICE_QUERY = `*[_type == "invoice"] | order(coalesce(issueDate, _create
   customerName,
   total,
   status,
-  _createdAt: coalesce(issueDate, _createdAt)
+  "_createdAt": coalesce(issueDate, _createdAt)
 }`
 
 const formatDate = (value?: string | null) => {


### PR DESCRIPTION
## Summary
- quote the `_createdAt` alias in the recent orders query to comply with GROQ syntax
- quote the `_createdAt` alias in the recent invoices query to prevent GROQ parsing errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd23b9fbb4832c80a09f7516def396