### PR TITLE
Exclude expired orders from unpaid list

### DIFF
--- a/packages/sanity-config/src/components/studio/OrdersDashboard.tsx
+++ b/packages/sanity-config/src/components/studio/OrdersDashboard.tsx
@@ -400,6 +400,7 @@ function matchesTab(order: OrderRow, key: TabKey): boolean {
     case 'unfulfilled':
       return fulfillment !== 'fulfilled' && !fulfillmentCancelled
     case 'unpaid':
+      if (fulfillment === 'expired') return false
       return !['paid', 'succeeded'].includes(payment) && !paymentClosed
     case 'open':
       if (fulfillmentCancelled || paymentClosed) return false

--- a/packages/sanity-config/src/desk/deskStructure.ts
+++ b/packages/sanity-config/src/desk/deskStructure.ts
@@ -164,7 +164,7 @@ export const deskStructure: StructureResolver = (S) =>
                     .apiVersion('2024-10-01')
                     .title('Unpaid orders')
                     .schemaType('order')
-                    .filter('_type == "order" && (paymentStatus != "paid" || !defined(paymentStatus))')
+                    .filter('_type == "order" && !(coalesce(status, "") in ["expired"]) && !(coalesce(paymentStatus, "") in ["paid", "expired"])')
                     .defaultOrdering([{field: 'createdAt', direction: 'desc'}])
                     .child(orderDocumentViews(S))
                 ),


### PR DESCRIPTION
## Summary
- exclude orders marked as expired from the "Unpaid / Failed" desk list by tightening the GROQ filter
- keep expired orders out of the Orders dashboard "Unpaid" tab so they only appear in the expired carts view

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68fd252e69f0832ca0f331d6b511a56b