### PR TITLE
Prefill Stripe reprocess action with session data

### DIFF
--- a/packages/sanity-config/src/schemaTypes/documentActions/reprocessStripeAction.ts
+++ b/packages/sanity-config/src/schemaTypes/documentActions/reprocessStripeAction.ts
@@ -5,12 +5,39 @@ export const reprocessStripeSessionAction: DocumentActionComponent = (props) => 
   const { published, onComplete } = props
   if (!published) return null
 
+  const doc = published as {
+    stripeSessionId?: string | null
+    paymentIntentId?: string | null
+    orderNumber?: string | null
+    _id?: string
+  }
+
+  const defaultId = [doc?.stripeSessionId, doc?.paymentIntentId]
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .find((value) => Boolean(value))
+
   return {
     label: 'Reprocess Stripe Session',
     onHandle: async () => {
       try {
-        const id = typeof window !== 'undefined' ? (window.prompt('Enter Stripe id (cs_… or pi_…):') || '').trim() : ''
+        let id = defaultId || ''
+
+        if (typeof window !== 'undefined') {
+          const orderRef = doc?.orderNumber?.trim() || doc?.stripeSessionId?.trim() || doc?._id || 'order'
+          if (id) {
+            const confirmed = window.confirm(
+              `Reprocess ${orderRef} using ${id}?\nClick "Cancel" to provide a different Stripe id.`,
+            )
+            if (!confirmed) {
+              id = (window.prompt('Enter Stripe id (cs_… or pi_…):', id) || '').trim()
+            }
+          } else {
+            id = (window.prompt('Enter Stripe id (cs_… or pi_…):') || '').trim()
+          }
+        }
+
         if (!id) return onComplete()
+
         const base = getNetlifyFnBase().replace(/\/$/, '')
         const res = await fetch(`${base}/.netlify/functions/reprocessStripeSession`, {
           method: 'POST',


### PR DESCRIPTION
## Summary
- default the Sanity reprocess Stripe action to the document's stored session or payment intent id
- fall back to prompting for a manual id when needed while keeping the existing workflow

## Testing
- pnpm lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68fdda68e150832c8f58b5e5fae97dbf