### PR TITLE
Add VS Code launch configuration for Sanity Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@ yarn-error.log*
 # OS / Editor junk
 .DS_Store
 Thumbs.db
-.vscode/
+.vscode/*
+!.vscode/launch.json
 *.swp
 *.swo
 *.save

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Sanity Studio in Chrome",
+      "type": "pwa-chrome",
+      "request": "launch",
+      "url": "http://localhost:3333",
+      "webRoot": "${workspaceFolder}",
+      "runtimeExecutable": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- allow the repository to track the VS Code launch configuration file
- add a Chrome launch profile for connecting to the Sanity Studio dev server with an explicit runtime path

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68fecad0d21c832cac224708517eb734