### PR TITLE
Configure Netlify dev workspace

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -22,6 +22,8 @@
   command = "pnpm run dev"
   targetPort = 3333
   port = 8888
+  framework = "#custom"
+  filter = "@fas/sanity-config"
 
 [dev.environment]
   SANITY_STUDIO_PORT = "3333"


### PR DESCRIPTION
## Summary
- configure the Netlify dev server to use the custom framework profile
- default the Netlify CLI to the @fas/sanity-config workspace when running in monorepos

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fecd549b7c832ca989dd43505aa67f