### PR TITLE
Patch Sanity number input wheel listener

### DIFF
--- a/patches/sanity@4.11.0.patch
+++ b/patches/sanity@4.11.0.patch
@@ -1,0 +1,45 @@
+*** Begin Patch
+*** Update File: lib/index.js
+@@
+-function preventWheel(event) {
+-  if (event.currentTarget && document.activeElement === event.currentTarget) {
+-    if (event.cancelable) {
+-      event.preventDefault();
+-    }
+-    const scrollContainer = getScrollableParent(event.currentTarget);
++function preventWheel(event) {
++  const element = event.currentTarget;
++  if (element && document.activeElement === element) {
++    if (typeof element.blur == "function") {
++      element.blur();
++    }
++    if (event.cancelable) {
++      event.preventDefault();
++    }
++    const scrollContainer = getScrollableParent(element);
+@@
+-    return element.addEventListener("wheel", preventWheel), () => {
++    return element.addEventListener("wheel", preventWheel, { passive: true }), () => {
+*** End Patch
+*** Update File: lib/index.mjs
+@@
+-function preventWheel(event) {
+-  if (event.currentTarget && document.activeElement === event.currentTarget) {
+-    if (event.cancelable) {
+-      event.preventDefault();
+-    }
+-    const scrollContainer = getScrollableParent(event.currentTarget);
++function preventWheel(event) {
++  const element = event.currentTarget;
++  if (element && document.activeElement === element) {
++    if (typeof element.blur == "function") {
++      element.blur();
++    }
++    if (event.cancelable) {
++      event.preventDefault();
++    }
++    const scrollContainer = getScrollableParent(element);
+@@
+-    return element.addEventListener("wheel", preventWheel), () => {
++    return element.addEventListener("wheel", preventWheel, { passive: true }), () => {
+*** End Patch


### PR DESCRIPTION
## Summary
- add a patch for `sanity@4.11.0` so the number input blurs before handling wheel events and can register a passive listener
- mark the wheel listener as passive while retaining the scroll forwarding behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fedb477084832cb04b03cc2656f71a