### PR TITLE
Improve pill button contrast

### DIFF
--- a/packages/sanity-config/src/schemaTypes/documents/invoiceStyles.css
+++ b/packages/sanity-config/src/schemaTypes/documents/invoiceStyles.css
@@ -59,9 +59,9 @@
 }
 
 .invoice-pill-button {
-  border: 1px solid #0077c5;
+  border: 1px solid #005b94;
   background-color: #e5f4fb;
-  color: #0077c5;
+  color: #005b94;
   border-radius: 999px;
   font-weight: 600;
   padding: 6px 14px;

--- a/packages/sanity-config/src/schemaTypes/documents/quoteStyles.css
+++ b/packages/sanity-config/src/schemaTypes/documents/quoteStyles.css
@@ -114,9 +114,9 @@
 }
 
 .quote-pill-button {
-  border: 1px solid #0077c5;
+  border: 1px solid #005b94;
   background-color: #e5f4fb;
-  color: #0077c5;
+  color: #005b94;
   border-radius: 999px;
   font-weight: 600;
   padding: 6px 14px;


### PR DESCRIPTION
## Summary
- darken the pill button text and border colors in the quote and invoice pill button styles to meet AA contrast on the light blue background

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68fef00ec8b4832cb7d3df57880c73e1