### PR TITLE
Define vision override flags

### DIFF
--- a/packages/sanity-config/sanity.config.ts
+++ b/packages/sanity-config/sanity.config.ts
@@ -83,6 +83,8 @@ const normalizeBaseUrl = (value?: string | null, fallback?: string): string | un
 
 const sanityEnv = getEnv('SANITY_STUDIO_ENV')
 const nodeEnv = getEnv('NODE_ENV')
+const enableVisionOverride = envFlag(getEnv('SANITY_STUDIO_ENABLE_VISION'))
+const disableVisionOverride = envFlag(getEnv('SANITY_STUDIO_DISABLE_VISION'))
 const enableVisualEditingOverride = envFlag(getEnv('SANITY_STUDIO_ENABLE_VISUAL_EDITING'))
 const disableVisualEditingOverride = envFlag(getEnv('SANITY_STUDIO_DISABLE_VISUAL_EDITING'))
 const presentationPreviewOrigin =


### PR DESCRIPTION
## Summary
- define SANITY Studio vision override flags so the config can load correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fef44fc910832ca8bda52f54f07b48