### PR TITLE
Add visual editing plugin to Sanity config

### DIFF
--- a/packages/sanity-config/sanity.config.ts
+++ b/packages/sanity-config/sanity.config.ts
@@ -18,6 +18,7 @@ import {visionTool} from '@sanity/vision'
 import {codeInput} from '@sanity/code-input'
 import {media} from 'sanity-plugin-media'
 import {presentationTool} from '@sanity/presentation'
+import {visualEditing} from '@sanity/visual-editing'
 import {definePreviewUrl} from '@sanity/preview-url-secret/define-preview-url'
 import {schemaMarkup} from '@operationnation/sanity-plugin-schema-markup'
 import {schemaTypes} from './src/schemaTypes'
@@ -240,6 +241,7 @@ export default defineConfig({
         },
       },
     }),
+    ...(visualEditingEnabled ? [visualEditing()] : []),
     ...(visionEnabled ? [visionTool()] : []),
   ],
 


### PR DESCRIPTION
## Summary
- import the @sanity/visual-editing plugin in the shared Sanity config
- register the plugin when visual editing is enabled so the studio can connect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fef950850c832c97263c17c96a851c