### PR TITLE
Add visual editing dependency to sanity config

### DIFF
--- a/packages/sanity-config/package.json
+++ b/packages/sanity-config/package.json
@@ -22,6 +22,7 @@
     "@sanity/preview-url-secret": "^2.1.15",
     "@sanity/ui": "latest",
     "@sanity/vision": "latest",
+    "@sanity/visual-editing": "^3.2.4",
     "@stripe/stripe-js": "^3.2.0",
     "date-fns": "^3.6.0",
     "jspdf": "^3.0.1",


### PR DESCRIPTION
## Summary
- add @sanity/visual-editing to the sanity-config package dependencies so the plugin can be resolved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff27565f28832c820d2a03fd8e296e