### PR TITLE
Fix shipping option patch event for ShipEngine service

### DIFF
--- a/packages/sanity-config/src/schemaTypes/documents/shippingOption.ts
+++ b/packages/sanity-config/src/schemaTypes/documents/shippingOption.ts
@@ -1,10 +1,10 @@
-import { defineType } from 'sanity'
+import { PatchEvent, defineType, set } from 'sanity'
 import React from 'react'
 import ShipEngineServiceInput from '../../components/ShipEngineServiceInput'
 
 interface ShipEngineFieldProps {
   value: string
-  onChange: (event: any) => void
+  onChange: (event: PatchEvent) => void
   type: any
   markers: any
   presence: any
@@ -104,10 +104,12 @@ function CustomShipEngineServiceField(props: ShipEngineFieldProps) {
                 {
                   type: 'button',
                   onClick: () => {
-                    props.onChange([
-                      { type: 'set', path: ['shipEngineService'], value: rate.value },
-                      { type: 'set', path: ['shippingCost'], value: rate.amount },
-                    ])
+                    props.onChange(
+                      PatchEvent.from([
+                        set(rate.value, ['shipEngineService']),
+                        set(rate.amount, ['shippingCost']),
+                      ]),
+                    )
                     setShowOptions(false)
                   },
                   style: {


### PR DESCRIPTION
## Summary
- wrap the ShipEngine shipping option field updates in `PatchEvent.from` to avoid unsupported patch types
- type the custom field change handler to expect a `PatchEvent`

## Testing
- pnpm exec eslint packages/sanity-config/src/schemaTypes/documents/shippingOption.ts

------
https://chatgpt.com/codex/tasks/task_e_68ff418357a4832ca765c66b9f7cedf1