### PR TITLE
Remove redundant toString when formatting refund currency

### DIFF
--- a/netlify/functions/stripeWebhook.ts
+++ b/netlify/functions/stripeWebhook.ts
@@ -1869,9 +1869,7 @@ export const handler: Handler = async (event) => {
                   ? [
                       refund?.status ? `Refund ${refund.status}` : null,
                       refundedAmount !== undefined
-                        ? `Amount ${refundedAmount.toFixed(2)} ${(refund?.currency || charge?.currency || '')
-                            .toString()
-                            .toUpperCase()}`
+                        ? `Amount ${refundedAmount.toFixed(2)} ${(refund?.currency || charge?.currency || '').toUpperCase()}`
                         : null,
                       charge?.id ? `Charge ${charge.id}` : null,
                     ]


### PR DESCRIPTION
## Summary
- remove the unnecessary `toString()` call when formatting the refund message currency in the Stripe webhook handler

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_690014156dd4832c88c76fb282ceb73f