### PR TITLE
Gate refund status updates on succeeded refunds

### DIFF
--- a/netlify/functions/stripeWebhook.ts
+++ b/netlify/functions/stripeWebhook.ts
@@ -1816,7 +1816,13 @@ export const handler: Handler = async (event) => {
               chargeAmountCents > 0 &&
               refundedCentsFromCharge >= chargeAmountCents)
 
-          const paymentStatus = isFullRefund ? 'refunded' : 'partially_refunded'
+          const refundStatus = typeof refund?.status === 'string' ? refund.status : undefined
+          const refundSucceeded = refundStatus === 'succeeded' || Boolean(charge?.refunded)
+          const paymentStatus = refundSucceeded
+            ? isFullRefund
+              ? 'refunded'
+              : 'partially_refunded'
+            : 'paid'
           const paymentIntentId =
             typeof paymentIntent?.id === 'string'
               ? paymentIntent.id
@@ -1829,8 +1835,8 @@ export const handler: Handler = async (event) => {
             paymentIntentId,
             chargeId: charge?.id || (typeof refund?.charge === 'string' ? refund.charge : undefined),
             paymentStatus,
-            orderStatus: isFullRefund ? 'refunded' : undefined,
-            invoiceStatus: isFullRefund ? 'refunded' : undefined,
+            orderStatus: refundSucceeded && isFullRefund ? 'refunded' : undefined,
+            invoiceStatus: refundSucceeded && isFullRefund ? 'refunded' : undefined,
             invoiceStripeStatus: webhookEvent.type,
             additionalOrderFields: {
               ...(refundedAmount !== undefined ? {amountRefunded: refundedAmount} : {}),


### PR DESCRIPTION
## Summary
- only mark orders refunded when the Stripe refund succeeds or the charge reports as fully refunded
- avoid updating order and invoice statuses for pending or failed refunds while continuing to capture refund metadata

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_69003715b398832c8849da843092648b