### PR TITLE
Reset order status after invoice payment succeeds

### DIFF
--- a/netlify/functions/stripeWebhook.ts
+++ b/netlify/functions/stripeWebhook.ts
@@ -2281,14 +2281,25 @@ export const handler: Handler = async (event) => {
                 eventType: webhookEvent.type,
                 eventCreated: webhookEvent.created,
               })
+              const additionalOrderFields = {
+                stripeSummary: summary,
+                paymentFailureCode: null,
+                paymentFailureMessage: null,
+              }
+              const additionalInvoiceFields = {
+                stripeSummary: summary,
+                paymentFailureCode: null,
+                paymentFailureMessage: null,
+              }
               await updateOrderPaymentStatus({
                 paymentIntentId,
                 chargeId,
                 paymentStatus: 'paid',
+                orderStatus: 'paid',
                 invoiceStatus: 'paid',
                 invoiceStripeStatus: webhookEvent.type,
-                additionalOrderFields: {stripeSummary: summary},
-                additionalInvoiceFields: {stripeSummary: summary},
+                additionalOrderFields,
+                additionalInvoiceFields,
                 event: {
                   eventType: webhookEvent.type,
                   label: 'Invoice payment succeeded',


### PR DESCRIPTION
## Summary
- ensure invoice payment success events restore the associated order status to paid
- clear stale payment failure diagnostics when an invoice payment completes successfully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69003a74a128832c9a5a5d09f9902b00