### PR TITLE
Allow creating discounts when field is read-only

### DIFF
--- a/packages/sanity-config/src/components/inputs/CustomerDiscountsInput.tsx
+++ b/packages/sanity-config/src/components/inputs/CustomerDiscountsInput.tsx
@@ -26,7 +26,7 @@ function sanitizeDocId(value?: string | null): string | undefined {
 type Props = ArrayInputProps<any>
 
 const CustomerDiscountsInput: React.FC<Props> = (props) => {
-  const {renderDefault, readOnly} = props
+  const {renderDefault} = props
   const toast = useToast()
 
   const stripeCustomerId = useFormValue(['stripeCustomerId']) as string | undefined
@@ -42,7 +42,12 @@ const CustomerDiscountsInput: React.FC<Props> = (props) => {
   const [currency, setCurrency] = useState('usd')
   const [isSubmitting, setSubmitting] = useState(false)
 
-  const disabled = readOnly || !stripeCustomerId
+  // The `discounts` field itself is marked as read-only in the schema so the
+  // array can't be edited manually, but we still want editors to be able to
+  // create new Stripe discounts from this input. Respect the presence of a
+  // Stripe customer ID but ignore the read-only flag for the button so the
+  // dialog remains accessible when the field is intentionally read-only.
+  const disabled = !stripeCustomerId
 
   async function handleSubmit() {
     if (!stripeCustomerId) {


### PR DESCRIPTION
## Summary
- ignore the array input's read-only flag when deciding whether to enable the "Create discount" button
- document why the button should stay enabled when the field is intentionally read-only

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69003a9f08f0832caa122943454fe97e