### PR TITLE
Load env before stripe webhook import in backfill script

### DIFF
--- a/scripts/backfill-checkout-async-payments.ts
+++ b/scripts/backfill-checkout-async-payments.ts
@@ -5,10 +5,6 @@ import fs from 'node:fs'
 import dotenv from 'dotenv'
 import Stripe from 'stripe'
 import {createClient} from '@sanity/client'
-import {
-  handleCheckoutAsyncPaymentFailed,
-  handleCheckoutAsyncPaymentSucceeded,
-} from '../netlify/functions/stripeWebhook'
 
 const ENV_FILES = ['.env.local', '.env.development', '.env']
 for (const filename of ENV_FILES) {
@@ -17,6 +13,11 @@ for (const filename of ENV_FILES) {
     dotenv.config({path: resolved, override: false})
   }
 }
+
+const {
+  handleCheckoutAsyncPaymentFailed,
+  handleCheckoutAsyncPaymentSucceeded,
+} = await import('../netlify/functions/stripeWebhook')
 
 type CliOptions = {
   dryRun: boolean


### PR DESCRIPTION
## Summary
- load environment variables before loading the stripe webhook helpers so they use configured credentials

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_69003abf478c832c9d8d42e9ee2f1886