### PR TITLE
Restore order status on invoice payment success

### DIFF
--- a/netlify/functions/stripeWebhook.ts
+++ b/netlify/functions/stripeWebhook.ts
@@ -2285,6 +2285,7 @@ export const handler: Handler = async (event) => {
                 paymentIntentId,
                 chargeId,
                 paymentStatus: 'paid',
+                orderStatus: 'paid',
                 invoiceStatus: 'paid',
                 invoiceStripeStatus: webhookEvent.type,
                 additionalOrderFields: {stripeSummary: summary},


### PR DESCRIPTION
## Summary
- ensure invoice payment success updates the related order status to `paid`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69003b46ea50832ca1f91d3dc765eac0