### PR TITLE
Fix refund status fallback for charge-only refund webhooks (follow-up)

### DIFF
--- a/netlify/functions/stripeWebhook.ts
+++ b/netlify/functions/stripeWebhook.ts
@@ -2668,7 +2668,11 @@ export const handler: Handler = async (event) => {
             (typeof refundedCentsFromRefund === 'number' && refundedCentsFromRefund > 0)
           const fallbackRefundSucceeded = !hasRefundStatus && chargeIndicatesRefund
           const refundSucceeded = refundStatus === 'succeeded' || fallbackRefundSucceeded
-          const preserveRefundedStatus = Boolean(refundStatus && refundStatus !== 'succeeded')
+          const preserveRefundedStatus = Boolean(
+            !fallbackRefundSucceeded &&
+              refundStatus &&
+              !['failed', 'pending', 'canceled', 'succeeded'].includes(refundStatus),
+          )
           const paymentStatus = refundSucceeded
             ? isFullRefund
               ? 'refunded'


### PR DESCRIPTION
## Summary
- fall back to charge-level refund indicators when webhook lacks a refund object
- ensure payment status and order updates still mark full or partial refunds
- disable refund-status preservation when the charge-only fallback is used or the refund reports a failed/pending/canceled status so later events can revert to paid

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690044f78660832ca0929beeeb11a0a7