### PR TITLE
Expand env flag parsing for vision override

### DIFF
--- a/packages/sanity-config/sanity.config.ts
+++ b/packages/sanity-config/sanity.config.ts
@@ -62,8 +62,8 @@ const envFlag = (value?: string | null) => {
 
   const normalized = value.trim().toLowerCase()
 
-  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true
-  if (['0', 'false', 'no', 'off'].includes(normalized)) return false
+  if (['1', 'true', 'yes', 'on', 'enable', 'enabled'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'off', 'disable', 'disabled'].includes(normalized)) return false
 
   return undefined
 }


### PR DESCRIPTION
## Summary
- allow envFlag to treat enable/disable strings as valid overrides so the Vision tool can be forced on

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6900602f43f8832c8fcaa72b68eb4110