### PR TITLE
Avoid Stripe payment intent lookups for checkout session IDs

### DIFF
--- a/netlify/functions/reprocessStripeSession.ts
+++ b/netlify/functions/reprocessStripeSession.ts
@@ -277,6 +277,12 @@ async function findSessionByPaymentIntent(paymentIntentId: string): Promise<Stri
 
 async function fetchPaymentIntent(id: string): Promise<Stripe.PaymentIntent | null> {
   if (!stripe) return null
+  if (!id.startsWith('pi_')) {
+    if (DEBUG_REPROCESS) {
+      console.debug('reprocessStripeSession: skip payment intent lookup for non-pi id', id)
+    }
+    return null
+  }
   try {
     return await stripe.paymentIntents.retrieve(id, {
       expand: ['latest_charge', 'charges.data'],


### PR DESCRIPTION
## Summary
- avoid calling the Stripe payment intent API for identifiers that do not start with `pi_`
- add debug logging when the lookup is skipped while debugging is enabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69006b4d80fc832cba41e463c81db3c0