### PR TITLE
Fix legacy order metadata conversion in Sanity studio

### DIFF
--- a/packages/sanity-config/src/components/inputs/OrderCartItemMetadataInput.tsx
+++ b/packages/sanity-config/src/components/inputs/OrderCartItemMetadataInput.tsx
@@ -1,0 +1,104 @@
+import {useEffect, useMemo} from 'react'
+import {Badge, Card, Flex, Stack, Text} from '@sanity/ui'
+import {ArrayOfObjectsInputProps, PatchEvent, set, unset} from 'sanity'
+import {normalizeMetadataEntries} from '../../utils/cartItemDetails'
+
+type MetadataEntry = {
+  _key?: string
+  _type?: string
+  key?: string
+  value?: string
+  source?: string
+}
+
+type MetadataValue = MetadataEntry[] | Record<string, unknown> | null | undefined
+
+const generateKey = () => {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID()
+  }
+  return Math.random().toString(36).slice(2)
+}
+
+const toMetadataEntries = (value: Record<string, unknown>): MetadataEntry[] => {
+  const normalized = normalizeMetadataEntries(value)
+  if (!normalized.length) return []
+  return normalized.map(({key, value: entryValue}) => ({
+    _key: generateKey(),
+    _type: 'orderCartItemMeta',
+    key,
+    value: entryValue,
+    source: 'legacy',
+  }))
+}
+
+const coerceMetadataArray = (value: MetadataValue): MetadataEntry[] | undefined => {
+  if (Array.isArray(value)) return value as MetadataEntry[]
+  if (value && typeof value === 'object' && Object.keys(value).length) {
+    return toMetadataEntries(value)
+  }
+  return undefined
+}
+
+const OrderCartItemMetadataInput = (props: ArrayOfObjectsInputProps<MetadataEntry>) => {
+  const {value, onChange} = props
+
+  useEffect(() => {
+    if (!value || Array.isArray(value)) return
+    if (typeof value !== 'object') {
+      onChange(PatchEvent.from(unset()))
+      return
+    }
+
+    const next = coerceMetadataArray(value as Record<string, unknown>)
+    if (!next) {
+      onChange(PatchEvent.from(unset()))
+      return
+    }
+
+    onChange(PatchEvent.from(set(next)))
+  }, [value, onChange])
+
+  const entries = useMemo(() => (Array.isArray(value) ? (value as MetadataEntry[]) : []), [value])
+
+  if (!entries.length) {
+    return (
+      <Card padding={3} tone="transparent" radius={2} border>
+        <Text size={1} muted>
+          No metadata available
+        </Text>
+      </Card>
+    )
+  }
+
+  return (
+    <Stack space={2} paddingY={1}>
+      {entries.map((entry) => {
+        const key = entry._key || entry.key || generateKey()
+        return (
+          <Card key={key} padding={3} radius={2} tone="transparent" border>
+            <Stack space={2}>
+              <Text size={1} weight="semibold">
+                {entry.key || 'Untitled'}
+              </Text>
+              {entry.value && (
+                <Text size={1} style={{wordBreak: 'break-word'}}>
+                  {entry.value}
+                </Text>
+              )}
+              {entry.source && (
+                <Flex>
+                  <Badge mode="outline" tone="primary" padding={2} radius={3}>
+                    Source: {entry.source}
+                  </Badge>
+                </Flex>
+              )}
+            </Stack>
+          </Card>
+        )
+      })}
+    </Stack>
+  )
+}
+
+export default OrderCartItemMetadataInput

--- a/packages/sanity-config/src/components/inputs/OrderCartItemMetadataInput.tsx
+++ b/packages/sanity-config/src/components/inputs/OrderCartItemMetadataInput.tsx
@@ -13,11 +13,13 @@ type MetadataEntry = {
 
 type MetadataValue = MetadataEntry[] | Record<string, unknown> | null | undefined
 
+const HAS_RANDOM_UUID = typeof globalThis.crypto?.randomUUID === 'function';
+
 const generateKey = () => {
-  if (typeof globalThis.crypto?.randomUUID === 'function') {
-    return globalThis.crypto.randomUUID()
+  if (HAS_RANDOM_UUID) {
+    return globalThis.crypto.randomUUID();
   }
-  return Math.random().toString(36).slice(2)
+  return Math.random().toString(36).slice(2);
 }
 
 const toMetadataEntries = (value: Record<string, unknown>): MetadataEntry[] => {

--- a/packages/sanity-config/src/schemaTypes/objects/orderCartItemType.ts
+++ b/packages/sanity-config/src/schemaTypes/objects/orderCartItemType.ts
@@ -1,4 +1,5 @@
 import { defineType, defineField } from 'sanity'
+import OrderCartItemMetadataInput from '../../components/inputs/OrderCartItemMetadataInput'
 
 export const orderCartItemType = defineType({
   name: 'orderCartItem',
@@ -13,6 +14,8 @@ export const orderCartItemType = defineType({
     defineField({ name: 'name', type: 'string', title: 'Display Name' }),
     defineField({ name: 'productName', type: 'string', title: 'Stripe Product Name', readOnly: true }),
     defineField({ name: 'description', type: 'string', title: 'Stripe Line Description', readOnly: true }),
+    defineField({ name: 'image', type: 'url', title: 'Product Image URL', readOnly: true }),
+    defineField({ name: 'productUrl', type: 'url', title: 'Product URL', readOnly: true }),
     defineField({ name: 'optionSummary', type: 'string', title: 'Selected Options', readOnly: true }),
     defineField({
       name: 'optionDetails',
@@ -32,13 +35,15 @@ export const orderCartItemType = defineType({
     }),
     defineField({ name: 'price', type: 'number', title: 'Unit Price' }),
     defineField({ name: 'quantity', type: 'number', title: 'Quantity' }),
-    defineField({ name: 'categories', title: 'Category Tags', type: 'array', of: [ { type: 'string' } ] }),
+    defineField({ name: 'categories', title: 'Category Tags', type: 'array', of: [{ type: 'string' }] }),
     defineField({
       name: 'metadata',
       title: 'Raw Metadata',
       type: 'array',
       of: [{ type: 'orderCartItemMeta' }],
-      readOnly: true,
+      components: {
+        input: OrderCartItemMetadataInput,
+      },
     }),
   ],
 })


### PR DESCRIPTION
## Summary
- add a custom cart item metadata input that coerces legacy object metadata into `orderCartItemMeta` entries
- surface product image and product URL fields on order cart items to avoid schema warnings

## Testing
- pnpm --filter @fas/sanity-config lint

------
https://chatgpt.com/codex/tasks/task_e_69006c74f8c4832c8fb259078fcc133c