### PR TITLE
Fix webhook handler type narrowing

### DIFF
--- a/scripts/backfill-checkout-async-payments.ts
+++ b/scripts/backfill-checkout-async-payments.ts
@@ -224,7 +224,9 @@ async function main() {
   }
 
   console.log(`Found ${orders.length} order(s) to evaluate.`)
-  const webhookHandlers = options.dryRun ? null : await loadWebhookHandlers()
+  const webhookHandlers: WebhookHandlers | null = options.dryRun
+    ? null
+    : await loadWebhookHandlers()
 
   let processed = 0
   let skipped = 0


### PR DESCRIPTION
## Summary
- narrow the webhook handler variable in the checkout async backfill script to match the helpers returned from loadWebhookHandlers

## Testing
- pnpm lint *(fails: netlify/functions/stripeWebhook.ts parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6900749b351c832c80d22a5b490659e6