### PR TITLE
Handle legacy order cart data in Sanity

### DIFF
--- a/packages/sanity-config/src/components/inputs/OrderCartItemsInput.tsx
+++ b/packages/sanity-config/src/components/inputs/OrderCartItemsInput.tsx
@@ -30,9 +30,10 @@ const toNumberValue = (value: unknown): number | undefined => {
   if (typeof value === 'string') {
     const trimmed = value.trim()
     if (!trimmed) return undefined
-    const normalized = trimmed.replace(/[^0-9.+-]+/g, '')
-    if (!normalized) return undefined
-    const parsed = Number.parseFloat(normalized)
+    // Only accept valid number strings (integer, float, optional sign, optional exponent)
+    const numberPattern = /^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/
+    if (!numberPattern.test(trimmed)) return undefined
+    const parsed = Number.parseFloat(trimmed)
     return Number.isFinite(parsed) ? parsed : undefined
   }
   return undefined

--- a/packages/sanity-config/src/components/inputs/OrderCartItemsInput.tsx
+++ b/packages/sanity-config/src/components/inputs/OrderCartItemsInput.tsx
@@ -1,0 +1,230 @@
+import {useEffect, useMemo} from 'react'
+import {ArrayOfObjectsInputProps, PatchEvent, set, unset} from 'sanity'
+import {normalizeMetadataEntries} from '../../utils/cartItemDetails'
+
+const HAS_RANDOM_UUID = typeof globalThis.crypto?.randomUUID === 'function'
+
+const generateKey = () => {
+  if (HAS_RANDOM_UUID) {
+    return globalThis.crypto.randomUUID()
+  }
+  return Math.random().toString(36).slice(2)
+}
+
+const toStringValue = (value: unknown): string | undefined => {
+  if (value === null || value === undefined) return undefined
+  if (typeof value === 'string') return value.trim() || undefined
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  try {
+    const json = JSON.stringify(value)
+    return json === undefined ? undefined : json
+  } catch {
+    return undefined
+  }
+}
+
+const toNumberValue = (value: unknown): number | undefined => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return undefined
+    const normalized = trimmed.replace(/[^0-9.+-]+/g, '')
+    if (!normalized) return undefined
+    const parsed = Number.parseFloat(normalized)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return undefined
+}
+
+const toStringArray = (value: unknown): string[] | undefined => {
+  if (!value) return undefined
+  if (Array.isArray(value)) {
+    const next = value
+      .map((entry) => toStringValue(entry))
+      .filter((entry): entry is string => Boolean(entry))
+    return next.length ? next : undefined
+  }
+  if (typeof value === 'string') {
+    try {
+      if (value.trim().startsWith('[')) {
+        const parsed = JSON.parse(value)
+        if (Array.isArray(parsed)) {
+          const next = parsed
+            .map((entry) => toStringValue(entry))
+            .filter((entry): entry is string => Boolean(entry))
+          if (next.length) return next
+        }
+      }
+    } catch {
+      // ignore json errors
+    }
+    const segments = value
+      .split(/[,;|]/g)
+      .map((part) => part.trim())
+      .filter(Boolean)
+    return segments.length ? segments : undefined
+  }
+  return undefined
+}
+
+const consume = (source: Record<string, unknown>, keys: string[]) => {
+  for (const key of keys) {
+    if (key in source) {
+      const value = source[key]
+      delete source[key]
+      return value
+    }
+  }
+  return undefined
+}
+
+const buildMetadataEntries = (
+  ...inputs: Array<unknown>
+): Array<{_key: string; _type: 'orderCartItemMeta'; key: string; value: string; source?: string}> => {
+  const entries = inputs.flatMap((input) => normalizeMetadataEntries(input))
+  return entries.map(({key, value}) => ({
+    _key: generateKey(),
+    _type: 'orderCartItemMeta',
+    key,
+    value,
+    source: 'legacy',
+  }))
+}
+
+type LegacyCartValue = unknown
+
+type OrderCartItem = {
+  _type: 'orderCartItem'
+  _key: string
+  id?: string
+  name?: string
+  productName?: string
+  productUrl?: string
+  image?: string
+  price?: number
+  quantity?: number
+  optionSummary?: string
+  optionDetails?: string[]
+  upgrades?: string[]
+  metadata?: ReturnType<typeof buildMetadataEntries>
+}
+
+const convertLegacyCartItem = (value: unknown): OrderCartItem | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const source = {...(value as Record<string, unknown>)}
+
+  delete source._type
+  delete source._key
+
+  const id = toStringValue(
+    consume(source, ['id', 'sanity_product_id', 'productId', 'product_id'])
+  )
+  const productName = toStringValue(
+    consume(source, ['productName', 'product_name', 'stripe_product_name'])
+  )
+  const name = toStringValue(consume(source, ['name', 'display_name'])) || productName || id
+  const productUrl = toStringValue(
+    consume(source, ['productUrl', 'product_url', 'url', 'product_path'])
+  )
+  const image = toStringValue(
+    consume(source, ['image', 'product_image', 'imageUrl', 'image_url'])
+  )
+  const price = toNumberValue(consume(source, ['price', 'unit_price', 'base_price']))
+  const quantity = toNumberValue(consume(source, ['quantity', 'qty', 'amount']))
+  const optionSummary = toStringValue(
+    consume(source, ['optionSummary', 'option_summary', 'options_readable'])
+  )
+  const optionDetails = toStringArray(
+    consume(source, ['optionDetails', 'option_details', 'selected_options'])
+  )
+  const upgrades = toStringArray(consume(source, ['upgrades', 'upgrade_list']))
+
+  const metadataValues: unknown[] = []
+  if ('metadata' in source) {
+    metadataValues.push(consume(source, ['metadata']) ?? undefined)
+  }
+  if ('raw_metadata' in source) {
+    metadataValues.push(consume(source, ['raw_metadata']) ?? undefined)
+  }
+
+  // Remaining fields on `source` should still be surfaced for context
+  metadataValues.push(source)
+
+  const metadata = buildMetadataEntries(...metadataValues)
+
+  const cartItem: OrderCartItem = {
+    _type: 'orderCartItem',
+    _key: generateKey(),
+  }
+
+  if (id) cartItem.id = id
+  if (name) cartItem.name = name
+  if (productName) cartItem.productName = productName
+  if (productUrl) cartItem.productUrl = productUrl
+  if (image) cartItem.image = image
+  if (typeof price === 'number') cartItem.price = price
+  if (typeof quantity === 'number') cartItem.quantity = quantity
+  if (optionSummary) cartItem.optionSummary = optionSummary
+  if (optionDetails?.length) cartItem.optionDetails = optionDetails
+  if (upgrades?.length) cartItem.upgrades = upgrades
+  if (metadata.length) cartItem.metadata = metadata
+
+  return cartItem
+}
+
+const normalizeLegacyCartValue = (value: LegacyCartValue): OrderCartItem[] | undefined => {
+  if (!value) return undefined
+  if (Array.isArray(value)) {
+    const next = value
+      .map((entry) => (Array.isArray(entry) ? undefined : convertLegacyCartItem(entry)))
+      .filter((entry): entry is OrderCartItem => Boolean(entry))
+    return next.length ? next : undefined
+  }
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    if (Array.isArray(record.items)) {
+      const next = record.items
+        .map((entry) => convertLegacyCartItem(entry))
+        .filter((entry): entry is OrderCartItem => Boolean(entry))
+      if (next.length) return next
+    }
+    if (Array.isArray(record.value)) {
+      const next = record.value
+        .map((entry) => convertLegacyCartItem(entry))
+        .filter((entry): entry is OrderCartItem => Boolean(entry))
+      if (next.length) return next
+    }
+    const single = convertLegacyCartItem(record)
+    return single ? [single] : undefined
+  }
+  return undefined
+}
+
+const OrderCartItemsInput = (props: ArrayOfObjectsInputProps<OrderCartItem>) => {
+  const {value, onChange, renderDefault} = props
+
+  const normalized = useMemo(() => normalizeLegacyCartValue(value), [value])
+
+  useEffect(() => {
+    if (!value) return
+    if (Array.isArray(value)) return
+
+    if (!normalized) {
+      onChange(PatchEvent.from(unset()))
+      return
+    }
+
+    onChange(PatchEvent.from(set(normalized)))
+  }, [value, normalized, onChange])
+
+  if (!Array.isArray(value) && normalized) {
+    return renderDefault({...props, value: normalized})
+  }
+
+  return renderDefault(props)
+}
+
+export default OrderCartItemsInput

--- a/packages/sanity-config/src/components/inputs/OrderCartItemsInput.tsx
+++ b/packages/sanity-config/src/components/inputs/OrderCartItemsInput.tsx
@@ -145,10 +145,10 @@ const convertLegacyCartItem = (value: unknown): OrderCartItem | null => {
 
   const metadataValues: unknown[] = []
   if ('metadata' in source) {
-    metadataValues.push(consume(source, ['metadata']) ?? undefined)
+    metadataValues.push(consume(source, ['metadata']))
   }
   if ('raw_metadata' in source) {
-    metadataValues.push(consume(source, ['raw_metadata']) ?? undefined)
+    metadataValues.push(consume(source, ['raw_metadata']))
   }
 
   // Remaining fields on `source` should still be surfaced for context

--- a/packages/sanity-config/src/schemaTypes/documents/order.tsx
+++ b/packages/sanity-config/src/schemaTypes/documents/order.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {defineField, defineType} from 'sanity'
 import FulfillmentBadge from '../../components/inputs/FulfillmentBadge'
+import OrderCartItemsInput from '../../components/inputs/OrderCartItemsInput'
 import OrderShippingActions from '../../components/studio/OrderShippingActions'
 
 const ORDER_MEDIA_URL =
@@ -142,6 +143,9 @@ export default defineType({
       type: 'array',
       of: [{type: 'orderCartItem'}],
       readOnly: true,
+      components: {
+        input: OrderCartItemsInput as any,
+      },
       group: 'cart',
     }),
     defineField({
@@ -151,6 +155,9 @@ export default defineType({
       of: [{type: 'orderCartItem'}],
       hidden: true,
       readOnly: true,
+      components: {
+        input: OrderCartItemsInput as any,
+      },
       group: 'cart',
     }),
     defineField({

--- a/packages/sanity-config/src/schemaTypes/objects/orderCartItemType.ts
+++ b/packages/sanity-config/src/schemaTypes/objects/orderCartItemType.ts
@@ -15,7 +15,7 @@ export const orderCartItemType = defineType({
     defineField({ name: 'productName', type: 'string', title: 'Stripe Product Name', readOnly: true }),
     defineField({ name: 'description', type: 'string', title: 'Stripe Line Description', readOnly: true }),
     defineField({ name: 'image', type: 'url', title: 'Product Image URL', readOnly: true }),
-    defineField({ name: 'productUrl', type: 'url', title: 'Product URL', readOnly: true }),
+    defineField({ name: 'productUrl', type: 'string', title: 'Product URL', readOnly: true }),
     defineField({ name: 'optionSummary', type: 'string', title: 'Selected Options', readOnly: true }),
     defineField({
       name: 'optionDetails',


### PR DESCRIPTION
## Summary
- add a custom cart array input that coerces legacy order data into `orderCartItem` objects and preserves metadata
- connect the new input to order cart and line item fields and relax product URL validation to allow stored relative paths

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_69007c1d9a10832ca0dc593bcd75d7c9