### PR TITLE
Preserve ShipEngine shipping metadata across Stripe and ShipStation

### DIFF
--- a/netlify/functions/getShippingQuoteBySkus.ts
+++ b/netlify/functions/getShippingQuoteBySkus.ts
@@ -327,6 +327,7 @@ export const handler: Handler = async (event) => {
 
     const ratesArr: any[] = Array.isArray(ratesJson?.rate_response?.rates) ? ratesJson.rate_response.rates : []
     const rates = ratesArr.map((rate: any) => ({
+      rateId: rate.rate_id,
       carrierId: rate.carrier_id,
       carrierCode: rate.carrier_code,
       carrier: rate.carrier_friendly_name,


### PR DESCRIPTION
## Summary
- include ShipEngine rate identifiers and service details when building Stripe Checkout shipping_rate_data metadata
- expose ShipEngine rate ids in the shipping quote API so downstream consumers can persist the selection
- enrich Stripe shipping resolution to merge metadata from stored shipping rates, ensuring selected service details sync to ShipStation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_690080bb3334832ca8e47049918c0493