### PR TITLE
Add SEO metadata fields and schema reference documents

### DIFF
--- a/packages/sanity-config/src/desk/deskStructure.ts
+++ b/packages/sanity-config/src/desk/deskStructure.ts
@@ -399,6 +399,29 @@ export const deskStructure: StructureResolver = (S, context) => {
 
   items.push(
     S.listItem()
+      .id('seo-and-schema')
+      .title('SEO & Schema')
+      .child(
+        S.list()
+          .title('SEO & Schema')
+          .items([
+            S.listItem()
+              .id('site-settings')
+              .title('Site settings')
+              .child(
+                S.document()
+                  .schemaType('settings')
+                  .documentId('settings')
+              ),
+            S.documentTypeListItem('schemaOrganization').title('Organization schema'),
+            S.documentTypeListItem('schemaProduct').title('Product schema'),
+            S.documentTypeListItem('schemaLocalBusiness').title('Local business schema'),
+          ])
+      )
+  )
+
+  items.push(
+    S.listItem()
       .id('online-store')
       .title('Online store')
       .child(

--- a/packages/sanity-config/src/schemaTypes/documents/schemaLocalBusiness.ts
+++ b/packages/sanity-config/src/schemaTypes/documents/schemaLocalBusiness.ts
@@ -1,0 +1,94 @@
+import {defineArrayMember, defineField, defineType} from 'sanity'
+
+export const schemaLocalBusinessType = defineType({
+  name: 'schemaLocalBusiness',
+  title: 'Schema.org Local Business',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+    }),
+    defineField({
+      name: 'url',
+      title: 'Website URL',
+      type: 'url',
+    }),
+    defineField({
+      name: 'image',
+      title: 'Primary image',
+      type: 'image',
+      options: {
+        hotspot: true,
+      },
+    }),
+    defineField({
+      name: 'priceRange',
+      title: 'Price range',
+      type: 'string',
+      description: 'For example: $$',
+    }),
+    defineField({
+      name: 'telephone',
+      title: 'Telephone',
+      type: 'string',
+    }),
+    defineField({
+      name: 'email',
+      title: 'Email',
+      type: 'email',
+    }),
+    defineField({
+      name: 'address',
+      title: 'Address',
+      type: 'schemaPostalAddress',
+    }),
+    defineField({
+      name: 'openingHours',
+      title: 'Opening hours',
+      type: 'array',
+      of: [defineArrayMember({type: 'string'})],
+      description: 'Use Schema.org opening hours format, e.g. Mo-Fr 09:00-17:00',
+    }),
+    defineField({
+      name: 'geo',
+      title: 'Geo coordinates',
+      type: 'object',
+      fields: [
+        defineField({
+          name: 'latitude',
+          title: 'Latitude',
+          type: 'number',
+        }),
+        defineField({
+          name: 'longitude',
+          title: 'Longitude',
+          type: 'number',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'sameAs',
+      title: 'Same As profiles',
+      type: 'array',
+      of: [defineArrayMember({type: 'url'})],
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'name',
+    },
+    prepare({title}) {
+      return {
+        title: title || 'Local business schema',
+      }
+    },
+  },
+})

--- a/packages/sanity-config/src/schemaTypes/documents/schemaOrganization.ts
+++ b/packages/sanity-config/src/schemaTypes/documents/schemaOrganization.ts
@@ -1,0 +1,64 @@
+import {defineArrayMember, defineField, defineType} from 'sanity'
+
+export const schemaOrganizationType = defineType({
+  name: 'schemaOrganization',
+  title: 'Schema.org Organization',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'legalName',
+      title: 'Legal name',
+      type: 'string',
+    }),
+    defineField({
+      name: 'url',
+      title: 'Website URL',
+      type: 'url',
+    }),
+    defineField({
+      name: 'logo',
+      title: 'Logo',
+      type: 'image',
+      options: {
+        hotspot: true,
+      },
+    }),
+    defineField({
+      name: 'address',
+      title: 'Address',
+      type: 'schemaPostalAddress',
+    }),
+    defineField({
+      name: 'contactEmail',
+      title: 'Contact email',
+      type: 'email',
+    }),
+    defineField({
+      name: 'contactPhone',
+      title: 'Contact phone',
+      type: 'string',
+    }),
+    defineField({
+      name: 'sameAs',
+      title: 'Same As profiles',
+      type: 'array',
+      of: [defineArrayMember({type: 'url'})],
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'name',
+    },
+    prepare({title}) {
+      return {
+        title: title || 'Organization schema',
+      }
+    },
+  },
+})

--- a/packages/sanity-config/src/schemaTypes/documents/schemaProduct.ts
+++ b/packages/sanity-config/src/schemaTypes/documents/schemaProduct.ts
@@ -1,0 +1,113 @@
+import {defineArrayMember, defineField, defineType} from 'sanity'
+
+export const schemaProductType = defineType({
+  name: 'schemaProduct',
+  title: 'Schema.org Product',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+    }),
+    defineField({
+      name: 'url',
+      title: 'Product URL',
+      type: 'url',
+    }),
+    defineField({
+      name: 'sku',
+      title: 'SKU',
+      type: 'string',
+    }),
+    defineField({
+      name: 'mpn',
+      title: 'MPN',
+      type: 'string',
+    }),
+    defineField({
+      name: 'gtin',
+      title: 'GTIN',
+      type: 'string',
+    }),
+    defineField({
+      name: 'brand',
+      title: 'Brand',
+      type: 'string',
+    }),
+    defineField({
+      name: 'images',
+      title: 'Images',
+      type: 'array',
+      of: [defineArrayMember({type: 'image'})],
+    }),
+    defineField({
+      name: 'offers',
+      title: 'Offers',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          name: 'offer',
+          title: 'Offer',
+          type: 'object',
+          fields: [
+            defineField({
+              name: 'price',
+              title: 'Price',
+              type: 'number',
+            }),
+            defineField({
+              name: 'priceCurrency',
+              title: 'Currency',
+              type: 'string',
+            }),
+            defineField({
+              name: 'availability',
+              title: 'Availability',
+              type: 'string',
+              description: 'Use Schema.org availability codes, e.g. https://schema.org/InStock',
+            }),
+            defineField({
+              name: 'url',
+              title: 'Offer URL',
+              type: 'url',
+            }),
+          ],
+        }),
+      ],
+    }),
+    defineField({
+      name: 'aggregateRating',
+      title: 'Aggregate rating',
+      type: 'object',
+      fields: [
+        defineField({
+          name: 'ratingValue',
+          title: 'Rating value',
+          type: 'number',
+        }),
+        defineField({
+          name: 'reviewCount',
+          title: 'Review count',
+          type: 'number',
+        }),
+      ],
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'name',
+    },
+    prepare({title}) {
+      return {
+        title: title || 'Product schema',
+      }
+    },
+  },
+})

--- a/packages/sanity-config/src/schemaTypes/index.ts
+++ b/packages/sanity-config/src/schemaTypes/index.ts
@@ -77,6 +77,7 @@ import {shippingOptionCustomerAddressType} from './objects/shippingOptionCustome
 import {shippingOptionDimensionsType} from './objects/shippingOptionDimensionsType'
 import {packageDetailsType} from './objects/packageDetailsType'
 import {seoType} from './objects/seoType'
+import {schemaPostalAddressType} from './objects/schemaPostalAddressType'
 import {shopifyCollectionType} from './objects/shopify/shopifyCollectionType'
 import {shopifyProductType} from './objects/shopify/shopifyProductType'
 import {shopifyProductVariantType} from './objects/shopify/shopifyProductVariantType'
@@ -87,6 +88,9 @@ import {stripeMetadataEntryType} from './objects/stripeMetadataEntry'
 import {stripePaymentMethodType} from './objects/stripePaymentMethodType'
 import tune from './documents/tune'
 import wheelQuote from './documents/wheelQuote'
+import {schemaOrganizationType} from './documents/schemaOrganization'
+import {schemaProductType} from './documents/schemaProduct'
+import {schemaLocalBusinessType} from './documents/schemaLocalBusiness'
 
 const annotations = [linkEmailType, linkExternalType, linkInternalType, linkProductType]
 
@@ -160,6 +164,7 @@ const objects = [
   shippingOptionDimensionsType,
   packageDetailsType,
   seoType,
+  schemaPostalAddressType,
   shopifyCollectionType,
   shopifyProductType,
   shopifyProductVariantType,
@@ -256,6 +261,9 @@ const documents = [
   booking,
   stripeWebhookEvent,
   stripeEvent,
+  schemaOrganizationType,
+  schemaProductType,
+  schemaLocalBusinessType,
 ]
 
 import {homeType} from './singletons/homeType'

--- a/packages/sanity-config/src/schemaTypes/objects/schemaPostalAddressType.ts
+++ b/packages/sanity-config/src/schemaTypes/objects/schemaPostalAddressType.ts
@@ -1,0 +1,34 @@
+import {defineField} from 'sanity'
+
+export const schemaPostalAddressType = defineField({
+  name: 'schemaPostalAddress',
+  title: 'Postal address',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'streetAddress',
+      title: 'Street address',
+      type: 'string',
+    }),
+    defineField({
+      name: 'addressLocality',
+      title: 'City / Locality',
+      type: 'string',
+    }),
+    defineField({
+      name: 'addressRegion',
+      title: 'State / Region',
+      type: 'string',
+    }),
+    defineField({
+      name: 'postalCode',
+      title: 'Postal code',
+      type: 'string',
+    }),
+    defineField({
+      name: 'addressCountry',
+      title: 'Country',
+      type: 'string',
+    }),
+  ],
+})

--- a/packages/sanity-config/src/schemaTypes/objects/seoType.ts
+++ b/packages/sanity-config/src/schemaTypes/objects/seoType.ts
@@ -12,20 +12,120 @@ export const seoType = defineField({
   fields: [
     defineField({
       name: 'title',
+      title: 'Meta title',
       type: 'string',
       validation: (Rule) =>
-        Rule.max(50).warning('Longer titles may be truncated by search engines'),
+        Rule.max(60).warning('Longer titles may be truncated by search engines'),
     }),
     defineField({
       name: 'description',
+      title: 'Meta description',
       type: 'text',
-      rows: 2,
+      rows: 3,
       validation: (Rule) =>
-        Rule.max(150).warning('Longer descriptions may be truncated by search engines'),
+        Rule.max(160).warning('Longer descriptions may be truncated by search engines'),
     }),
     defineField({
       name: 'image',
+      title: 'Default share image',
       type: 'image',
+      options: {
+        hotspot: true,
+      },
+    }),
+    defineField({
+      name: 'canonicalUrl',
+      title: 'Canonical URL',
+      type: 'url',
+    }),
+    defineField({
+      name: 'openGraph',
+      title: 'Open Graph overrides',
+      type: 'object',
+      options: {
+        collapsed: true,
+        collapsible: true,
+      },
+      fields: [
+        defineField({
+          name: 'title',
+          title: 'Title',
+          type: 'string',
+        }),
+        defineField({
+          name: 'description',
+          title: 'Description',
+          type: 'text',
+          rows: 2,
+        }),
+        defineField({
+          name: 'type',
+          title: 'Type',
+          type: 'string',
+          options: {
+            list: [
+              {title: 'Website', value: 'website'},
+              {title: 'Article', value: 'article'},
+              {title: 'Product', value: 'product'},
+            ],
+          },
+        }),
+        defineField({
+          name: 'image',
+          title: 'Image',
+          type: 'image',
+          options: {
+            hotspot: true,
+          },
+        }),
+      ],
+    }),
+    defineField({
+      name: 'jsonLd',
+      title: 'JSON-LD',
+      type: 'object',
+      options: {
+        collapsed: true,
+        collapsible: true,
+      },
+      fields: [
+        defineField({
+          name: 'type',
+          title: 'Type',
+          type: 'string',
+          options: {
+            list: [
+              {title: 'Organization', value: 'schemaOrganization'},
+              {title: 'Product', value: 'schemaProduct'},
+              {title: 'Local business', value: 'schemaLocalBusiness'},
+            ],
+          },
+        }),
+        defineField({
+          name: 'reference',
+          title: 'Reference',
+          type: 'reference',
+          to: [
+            {type: 'schemaOrganization'},
+            {type: 'schemaProduct'},
+            {type: 'schemaLocalBusiness'},
+          ],
+        }),
+      ],
+      validation: (Rule) =>
+        Rule.custom((value) => {
+          if (!value) return true
+
+          if (value.type && !value.reference) {
+            return 'Select a schema reference to match the JSON-LD type'
+          }
+
+          if (!value.type && value.reference) {
+            return 'Choose a JSON-LD type to match the selected reference'
+          }
+
+          return true
+        }),
     }),
   ],
 })


### PR DESCRIPTION
## Summary
- extend the shared SEO object with canonical, Open Graph, and JSON-LD reference fields
- add reusable postal address object and schema.org reference documents for Organization, Product, and Local Business
- surface new schema documents alongside site settings in the desk structure for easy editing

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_6902ee45bfd4832c94cdad1b4de35ee7