### PR TITLE
Fix Stripe webhook bundling issues (follow-up)

### DIFF
--- a/netlify/functions/stripeWebhook.ts
+++ b/netlify/functions/stripeWebhook.ts
@@ -2919,7 +2919,7 @@ const getCheckoutAsyncDefaults = (
   return {metadata, eventType, invoiceStripeStatus, amount, currency}
 }
 
-async function handleCheckoutAsyncPaymentSucceeded(
+export async function handleCheckoutAsyncPaymentSucceeded(
   session: Stripe.Checkout.Session,
   context: CheckoutAsyncContext = {},
 ): Promise<void> {


### PR DESCRIPTION
## Summary
- restore the exported `handleCheckoutAsyncPaymentSucceeded` function so the backfill script can import it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902f43aade4832c954de72d2ed4ce95