### PR TITLE
fix: parenthesize order search filters

### DIFF
--- a/packages/sanity-config/src/groq/orders.ts
+++ b/packages/sanity-config/src/groq/orders.ts
@@ -295,7 +295,12 @@ export async function listByFilters(
     // PERFORMANCE NOTE: For large datasets, ensure 'orderNumber', 'customerName', and 'customerEmail'
     // are indexed in the Sanity schema to optimize search performance.
     filters.push(
-      'string(orderNumber) match $searchPattern || customerName match $searchPattern || customerEmail match $searchPattern || _id match $searchPattern',
+      `(${[
+        'string(orderNumber) match $searchPattern',
+        'customerName match $searchPattern',
+        'customerEmail match $searchPattern',
+        '_id match $searchPattern',
+      ].join(' || ')})`,
     )
     queryParams.searchPattern = pattern
   }


### PR DESCRIPTION
## Summary
- wrap the order search clause in parentheses so it is combined with other filters using logical AND

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_6902f431e304832c9b303c3c344ffd19