### PR TITLE
fix: repair seo schema definition

### DIFF
--- a/netlify/functions/syncMerchantProducts.ts
+++ b/netlify/functions/syncMerchantProducts.ts
@@ -56,8 +56,10 @@ function toPositiveNumber(value: unknown): number | undefined {
   return undefined
 }
 
-function buildProductLink(slug?: any, canonicalUrl?: string): string | undefined {
-  if (canonicalUrl) return canonicalUrl
+function buildProductLink(product: any): string | undefined {
+  const canonical = product?.canonicalUrl || product?.seo?.canonicalUrl
+  if (canonical) return canonical
+  const slug = product?.slug
   const slugStr = slug?.current || slug
   if (SITE_BASE_URL && typeof slugStr === 'string' && slugStr.trim()) {
     return `${SITE_BASE_URL}/product/${slugStr}`
@@ -145,7 +147,10 @@ const content = google.content({ version: 'v2.1', auth })
         shortDescription,
         description,
         brand,
-        canonicalUrl,
+        "canonicalUrl": coalesce(canonicalUrl, seo.canonicalUrl),
+        "seo": {
+          "canonicalUrl": seo.canonicalUrl
+        },
         googleProductCategory,
         google_product_category,
         "images": images[].asset->url,
@@ -159,7 +164,7 @@ const content = google.content({ version: 'v2.1', auth })
     products.forEach((product: any, index: number) => {
       try {
       const offerId = (product?.sku || product?._id || '').toString().trim()
-      const link = buildProductLink(product?.slug, product?.canonicalUrl)
+      const link = buildProductLink(product)
       const imageLink = buildImageUrl(product?.images || [])
       const price = toPositiveNumber(product?.price)
       if (!offerId || !price || !link || !imageLink) {

--- a/packages/sanity-config/src/schemaTypes/objects/seoType.ts
+++ b/packages/sanity-config/src/schemaTypes/objects/seoType.ts
@@ -12,7 +12,6 @@ export const seoType = defineField({
   fields: [
     defineField({
       name: 'metaTitle',
-      name: 'title',
       title: 'Meta title',
       type: 'string',
       description: 'Optimised title tag (50-60 characters recommended).',
@@ -25,52 +24,30 @@ export const seoType = defineField({
       type: 'text',
       rows: 3,
       description: 'Compelling summary that encourages clicks (140-160 characters recommended).',
-      name: 'description',
-      title: 'Meta description',
-      type: 'text',
-      rows: 3,
       validation: (Rule) =>
         Rule.max(160).warning('Longer descriptions may be truncated by search engines'),
-    }),
-    defineField({
-      name: 'openGraph',
-      title: 'Open Graph',
-      type: 'object',
-      options: {
-        collapsible: true,
-        collapsed: true,
-      },
-      fields: [
-        defineField({
-          name: 'image',
-          title: 'Preview image',
-          type: 'image',
-          options: {hotspot: true},
-          fields: [
-            defineField({
-              name: 'alt',
-              title: 'Alt text',
-              type: 'string',
-              description: 'Short, keyword-rich description for screen readers and social previews.',
-            }),
-          ],
-        }),
-        defineField({
-          name: 'url',
-          title: 'Open Graph URL',
-          type: 'url',
-          description: 'Explicit share URL for social previews when different from the canonical link.',
-      name: 'image',
-      title: 'Default share image',
-      type: 'image',
-      options: {
-        hotspot: true,
-      },
     }),
     defineField({
       name: 'canonicalUrl',
       title: 'Canonical URL',
       type: 'url',
+      description: 'Preferred URL for search engines when duplicate content exists.',
+    }),
+    defineField({
+      name: 'shareImage',
+      title: 'Default share image',
+      type: 'image',
+      options: {
+        hotspot: true,
+      },
+      fields: [
+        defineField({
+          name: 'alt',
+          title: 'Alt text',
+          type: 'string',
+          description: 'Short, keyword-rich description for screen readers and social previews.',
+        }),
+      ],
     }),
     defineField({
       name: 'openGraph',
@@ -105,6 +82,12 @@ export const seoType = defineField({
           },
         }),
         defineField({
+          name: 'url',
+          title: 'Open Graph URL',
+          type: 'url',
+          description: 'Explicit share URL for social previews when different from the canonical link.',
+        }),
+        defineField({
           name: 'image',
           title: 'Image',
           type: 'image',
@@ -115,17 +98,6 @@ export const seoType = defineField({
       ],
     }),
     defineField({
-      name: 'canonicalUrl',
-      title: 'Canonical URL',
-      type: 'url',
-      description: 'Preferred URL for search engines when duplicate content exists.',
-    }),
-    defineField({
-      name: 'jsonLd',
-      title: 'Structured data (JSON-LD)',
-      type: 'text',
-      rows: 6,
-      description: 'Paste raw JSON-LD to enhance search engine rich results.',
       name: 'jsonLd',
       title: 'JSON-LD',
       type: 'object',

--- a/scripts/upload-google-merchant-sftp.ts
+++ b/scripts/upload-google-merchant-sftp.ts
@@ -41,6 +41,9 @@ type SanityProduct = {
   description?: unknown
   brand?: string | null
   canonicalUrl?: string | null
+  seo?: {
+    canonicalUrl?: string | null
+  } | null
   images?: Array<{asset?: {url?: string | null} | null}> | string[]
   categories?: string[] | null
   googleProductCategory?: string | null
@@ -138,7 +141,10 @@ const QUERY = `*[_type == "product" && defined(price) && price > 0]{
   shortDescription,
   description,
   brand,
-  canonicalUrl,
+  "canonicalUrl": coalesce(canonicalUrl, seo.canonicalUrl),
+  "seo": {
+    "canonicalUrl": seo.canonicalUrl
+  }
   "images": images[]{
     asset->{url}
   },
@@ -205,7 +211,11 @@ function selectDescription(product: SanityProduct): string {
 }
 
 function buildProductLink(product: SanityProduct): string {
-  if (product.canonicalUrl) return sanitizeText(product.canonicalUrl)
+  const canonical =
+    product.canonicalUrl ||
+    product.seo?.canonicalUrl ||
+    undefined
+  if (canonical) return sanitizeText(canonical)
   const slug = typeof product.slug === 'object' ? product.slug?.current : undefined
   if (SITE_BASE_URL && slug) {
     return `${SITE_BASE_URL}/product/${slug}`


### PR DESCRIPTION
## Summary
- rebuild the seo object schema to remove duplicate fields and invalid syntax
- ensure canonical url, open graph, and json-ld sections are defined with proper structure

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_6902f42a4440832c9bb725f6a242c3cc