### PR TITLE
fix: prefer seo canonical url when loading bulk editor

### DIFF
--- a/packages/sanity-config/src/components/studio/ProductBulkEditor.tsx
+++ b/packages/sanity-config/src/components/studio/ProductBulkEditor.tsx
@@ -532,7 +532,7 @@ export default function ProductBulkEditor() {
             shippingWeight,
             boxDimensions,
             brand,
-            "canonicalUrl": coalesce(canonicalUrl, seo.canonicalUrl),
+            "canonicalUrl": coalesce(seo.canonicalUrl, canonicalUrl),
             "seo": {
               "canonicalUrl": seo.canonicalUrl
             },


### PR DESCRIPTION
## Summary
- load product canonical URL in the bulk editor preferring seo.canonicalUrl over the legacy field

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902f68c6bcc832c8d17c370a6197f37