### PR TITLE
fix: surface canonical url for product feeds

### DIFF
--- a/packages/sanity-config/src/components/studio/ProductBulkEditor.tsx
+++ b/packages/sanity-config/src/components/studio/ProductBulkEditor.tsx
@@ -532,7 +532,7 @@ export default function ProductBulkEditor() {
             shippingWeight,
             boxDimensions,
             brand,
-            "canonicalUrl": coalesce(canonicalUrl, seo.canonicalUrl),
+            "canonicalUrl": coalesce(seo.canonicalUrl, canonicalUrl),
             "seo": {
               "canonicalUrl": seo.canonicalUrl
             },


### PR DESCRIPTION
## Summary
- prioritize `seo.canonicalUrl` when populating bulk editor canonical URLs to avoid overwriting newer values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902f686d430832caa4eb3eda3c5410f