### PR TITLE
fix: preserve seo canonical precedence in bulk editor

### DIFF
--- a/packages/sanity-config/src/components/studio/ProductBulkEditor.tsx
+++ b/packages/sanity-config/src/components/studio/ProductBulkEditor.tsx
@@ -89,7 +89,7 @@ function sanitizeNumber(value: string, fallback?: number): number | undefined {
 }
 
 function buildProductLink(product: ProductDoc): string {
-  const canonical = product.canonicalUrl || product.seo?.canonicalUrl || ''
+  const canonical = product.seo?.canonicalUrl || product.canonicalUrl || ''
   if (canonical) return canonical
   const slug = product.slug?.current || ''
   if (!slug) return ''
@@ -532,7 +532,7 @@ export default function ProductBulkEditor() {
             shippingWeight,
             boxDimensions,
             brand,
-            "canonicalUrl": coalesce(canonicalUrl, seo.canonicalUrl),
+            "canonicalUrl": coalesce(seo.canonicalUrl, canonicalUrl),
             "seo": {
               "canonicalUrl": seo.canonicalUrl
             },
@@ -858,7 +858,7 @@ export default function ProductBulkEditor() {
     if (!product._id) return
     try {
       updateProductField(product._id, 'isSaving', true)
-      const canonicalUrlValue = (product.canonicalUrl || product.seo?.canonicalUrl || '')
+      const canonicalUrlValue = (product.seo?.canonicalUrl || product.canonicalUrl || '')
         .toString()
         .trim()
 


### PR DESCRIPTION
## Summary
- prefer `seo.canonicalUrl` when building product links so the bulk editor shows the latest canonical value
- prioritize `seo.canonicalUrl` when preparing save payloads to avoid overwriting newer SEO canonicals

## Testing
- pnpm lint *(fails: packages/sanity-config/src/schemaTypes/objects/seoType.ts 177:0 Parsing error: ']' expected)*

------
https://chatgpt.com/codex/tasks/task_e_6902f686d430832caa4eb3eda3c5410f