### PR TITLE
Include item name option segments in packing slip details

### DIFF
--- a/netlify/functions/backfillCheckoutAsyncPayments.ts
+++ b/netlify/functions/backfillCheckoutAsyncPayments.ts
@@ -62,7 +62,7 @@ export const handler: Handler = async (event) => {
   if (event.body) {
     try {
       payload = JSON.parse(event.body)
-    } catch (err) {
+    } catch {
       return {
         statusCode: 400,
         headers: {...CORS, 'Content-Type': 'application/json'},

--- a/netlify/functions/generatePackingSlips.ts
+++ b/netlify/functions/generatePackingSlips.ts
@@ -262,7 +262,11 @@ const prepareItemPresentation = (source: {
   const metadataEntries = normalizeMetadataEntries(source.metadata as any)
   const derived = deriveCartOptions(metadataEntries)
   const rawName = (source?.name || source?.description || source?.productName || source?.title || source?.sku || 'Item').toString()
-  const title = rawName.split('•')[0]?.trim() || rawName
+  const nameSegments = rawName
+    .split('•')
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+  const title = nameSegments[0] || rawName
   const summary = (source.optionSummary || derived.optionSummary || '').toString().trim() || undefined
   const optionDetails = uniqueStrings([
     ...coerceStringArray(source.optionDetails),
@@ -284,6 +288,14 @@ const prepareItemPresentation = (source: {
     if (detailSet.has(normalized)) return
     detailSet.add(normalized)
     details.push(detail)
+  }
+  if (nameSegments.length > 1) {
+    for (const segment of nameSegments.slice(1)) {
+      const normalized = segment.replace(/\s+/g, ' ').trim()
+      if (!normalized) continue
+      if (!shouldDisplayMetadataSegment(normalized)) continue
+      appendDetail(normalized)
+    }
   }
   const rawSkuCandidates = [
     source?.sku,

--- a/packages/sanity-config/sanity.config.ts
+++ b/packages/sanity-config/sanity.config.ts
@@ -193,7 +193,9 @@ const visionEnabled =
 const visualEditingEnabled =
   disableVisualEditingOverride === true
     ? false
-    : true
+    : enableVisualEditingOverride !== undefined
+      ? enableVisualEditingOverride
+      : true
 
 export default defineConfig({
   name: 'default',


### PR DESCRIPTION
## Summary
- derive packing slip line-item details from bullet-separated portions of the item name
- skip empty or filtered segments so only meaningful option metadata is displayed
- respect SANITY_STUDIO_ENABLE_VISUAL_EDITING overrides while keeping lint checks clean

## Testing
- pnpm lint


------
https://chatgpt.com/codex/tasks/task_e_6904f0852bac832caccea83f64a25f53