### PR TITLE
Fix missing codemirror dependency for Sanity Vision

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@sanity/vision": "latest",
     "@operationnation/sanity-plugin-schema-markup": "^2.0.0",
     "@sanity/visual-editing": "^4.0.0",
+    "codemirror": "^6.0.0",
     "@stripe/stripe-js": "^3.2.0",
     "astro": "^5.7.5",
     "axios": "^1.11.0",

--- a/packages/sanity-config/package.json
+++ b/packages/sanity-config/package.json
@@ -23,6 +23,7 @@
     "@sanity/ui": "latest",
     "@sanity/vision": "latest",
     "@sanity/visual-editing": "^4.0.0",
+    "codemirror": "^6.0.0",
     "@stripe/stripe-js": "^3.2.0",
     "date-fns": "^3.6.0",
     "jspdf": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       '@sanity/visual-editing':
         specifier: ^4.0.0
         version: 4.0.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.12.0)(@sanity/types@4.11.0(@types/react@18.3.24))(react-dom@18.3.1(react@18.3.1))(react-is@19.1.1)(react@18.3.1)(sanity@4.11.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.1.15(@sanity/schema@4.11.0(@types/react@18.3.24)(debug@4.4.3))(@sanity/types@4.11.0(@types/react@18.3.24)))(@types/node@22.18.12)(@types/react@18.3.24)(canvas@3.2.0)(immer@10.1.3)(jiti@1.21.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)
+      codemirror:
+        specifier: ^6.0.0
+        version: 6.0.2
       '@stripe/stripe-js':
         specifier: ^3.2.0
         version: 3.5.0
@@ -230,6 +233,9 @@ importers:
       '@sanity/visual-editing':
         specifier: ^4.0.0
         version: 4.0.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.12.0)(@sanity/types@4.11.0(@types/react@18.3.24))(react-dom@18.3.1(react@18.3.1))(react-is@19.1.1)(react@18.3.1)(sanity@4.11.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.1.15(@sanity/schema@4.11.0(@types/react@18.3.24))(@sanity/types@4.11.0(@types/react@18.3.24)))(@types/node@22.18.12)(@types/react@18.3.24)(canvas@3.2.0)(immer@10.1.3)(jiti@2.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)
+      codemirror:
+        specifier: ^6.0.0
+        version: 6.0.2
       '@stripe/stripe-js':
         specifier: ^3.2.0
         version: 3.5.0


### PR DESCRIPTION
## Summary
- add codemirror as a direct dependency for the workspace and Sanity config packages so the Vision tool can be enabled without peer dependency errors
- update the lockfile to record the new codemirror dependency

## Testing
- pnpm install --frozen-lockfile

------
https://chatgpt.com/codex/tasks/task_e_69051448851c832caba328c03d2fa507