### PR TITLE
Filter order list to completed checkouts

### DIFF
--- a/packages/sanity-config/src/components/studio/OrderListPane.tsx
+++ b/packages/sanity-config/src/components/studio/OrderListPane.tsx
@@ -50,6 +50,8 @@ type SortDefinition = {
   direction: 'asc' | 'desc'
 }
 
+const BASE_FILTER = 'count(orderEvents[type == "checkout.session.completed"]) > 0'
+
 const FILTERS: FilterDefinition[] = [
   {id: 'recent', title: 'Recent', description: 'Newest orders first'},
   {
@@ -284,6 +286,14 @@ function OrdersTableContent() {
     [sortId],
   )
 
+  const combinedFilter = useMemo(() => {
+    const filterExpression = activeFilter.filter?.trim()
+    if (filterExpression && filterExpression.length > 0) {
+      return `(${BASE_FILTER}) && (${filterExpression})`
+    }
+    return BASE_FILTER
+  }, [activeFilter.filter])
+
   const {
     data,
     isPending,
@@ -297,7 +307,7 @@ function OrdersTableContent() {
   } = usePaginatedDocuments({
     documentType: 'order',
     pageSize: PAGE_SIZE,
-    filter: activeFilter.filter,
+    filter: combinedFilter,
     orderings: [{field: activeSort.field, direction: activeSort.direction}],
   })
 


### PR DESCRIPTION
## Summary
- ensure the Sanity orders pane only lists documents with a checkout.session.completed event
- combine existing menu filters with the base condition so additional filtering still works

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905c69eef98832c9317805778427b9c