### PR TITLE
Add Netlify redirect for fasmotorsports.us domain

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -53,6 +53,13 @@
   to = "/assets/:splat"
   status = 200
 
+[[redirects]]
+  from = "/*"
+  to = "https://www.fasmotorsports.com/:splat"
+  status = 301
+  force = true
+  conditions = { Host = ["fasmotorsports.us", "www.fasmotorsports.us"] }
+
 # Catch-all redirect for everything else
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## Summary
- add a domain-specific Netlify redirect that forces fasmotorsports.us traffic to fasmotorsports.com
- preserve the request path while redirecting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69085242e530832c837a26de05f65db0