### PR TITLE
Harden calendar task sync with shared utils and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "deploy-graphql": "sanity graphql deploy",
     "lint": "eslint --max-warnings=0 .",
     "inspect-checkout": "tsx scripts/inspect-checkout-session.ts",
+    "test": "vitest run",
     "backfill:shipping": "tsx scripts/backfill-order-shipping.ts",
     "backfill:customers": "tsx scripts/invoke-netlify-function.ts backfillCustomers '{\"dryRun\":false}'",
     "backfill:orders": "tsx scripts/invoke-netlify-function.ts backfillOrders '{\"dryRun\":false}'",
@@ -99,7 +100,8 @@
     "prettier": "^3.0.2",
     "tailwindcss": "^3.4.18",
     "tsx": "^4.20.6",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "vitest": "^2.1.4"
   },
   "prettier": {
     "semi": false,

--- a/packages/sanity-config/sanity.config.ts
+++ b/packages/sanity-config/sanity.config.ts
@@ -28,6 +28,7 @@ import resolveDocumentBadges from './src/documentBadges'
 import StudioLayout from './src/components/studio/StudioLayout'
 import {fasTheme} from './src/theme/fasTheme'
 import {fasBrandTheme} from './src/theme/fasBrandTheme'
+import {calendarApp} from './src/apps/calendar'
 
 const hasProcess = typeof process !== 'undefined' && typeof process.cwd === 'function'
 const joinSegments = (...segments: string[]) => segments.filter(Boolean).join('/')
@@ -226,6 +227,7 @@ export default defineConfig({
       structure: deskStructure,
     }),
     deskStructureBuilderTool(),
+    calendarApp(),
     media(),
     codeInput(),
     schemaMarkup(),

--- a/packages/sanity-config/src/apps/calendar/CalendarApp.tsx
+++ b/packages/sanity-config/src/apps/calendar/CalendarApp.tsx
@@ -1177,7 +1177,7 @@ const CalendarApp = React.forwardRef<HTMLDivElement>((_props, ref) => {
                                                 content={
                                                   <Box padding={2} style={{maxWidth: 220}}>
                                                     <Text size={1}>
-                                                      {TASK_BADGE_DESCRIPTIONS[variant]}
+                                                      {TASK_BADGE_DESCRIPTIONS[taskBadge.variant]}
                                                     </Text>
                                                   </Box>
                                                 }

--- a/packages/sanity-config/src/apps/calendar/CalendarApp.tsx
+++ b/packages/sanity-config/src/apps/calendar/CalendarApp.tsx
@@ -524,7 +524,7 @@ const CalendarApp = React.forwardRef<HTMLDivElement>((_props, ref) => {
       if (!records.length) return ''
       if (records.length === 1) return records[0]
       const [first, second, ...rest] = records
-      return rest.length > 0 ? `${first}, ${second}${rest.length ? ` +${rest.length} more` : ''}` : `${first}, ${second}`
+      return rest.length > 0 ? `${first}, ${second} +${rest.length} more` : `${first}, ${second}`
     }
 
     if (createdSummaries.length > 0) {

--- a/packages/sanity-config/src/apps/calendar/CalendarApp.tsx
+++ b/packages/sanity-config/src/apps/calendar/CalendarApp.tsx
@@ -1,0 +1,1653 @@
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  Flex,
+  Heading,
+  Inline,
+  Spinner,
+  Stack,
+  Text,
+  Tooltip,
+  useToast,
+} from '@sanity/ui'
+import {AddIcon, BellIcon, ChevronLeftIcon, ChevronRightIcon, EditIcon, RefreshIcon} from '@sanity/icons'
+import {
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  formatDistanceToNow,
+  isBefore,
+  isSameDay,
+  isSameMonth,
+  isToday,
+  parseISO,
+  startOfMonth,
+  startOfWeek,
+  subMonths,
+} from 'date-fns'
+import {useClient} from 'sanity'
+import {useRouter} from 'sanity/router'
+
+import {
+  BookingCustomer,
+  CalendarBooking,
+  CalendarTask,
+  TASK_BADGE_DESCRIPTIONS,
+  TASK_BADGE_STYLES,
+  computeSnoozedReminder,
+  computeTaskSyncPlan,
+  computeTaskTiming,
+  formatDateForStorage,
+  isoTimesEqual,
+  deriveBookingStatusFromTaskAction,
+  parseDateSafe,
+  resolveTaskBadge,
+  summarizeTaskBadges,
+  withRetry,
+} from './shared'
+
+const CUSTOMER_PROJECTION = `{
+  _id,
+  firstName,
+  lastName,
+  name,
+  email,
+  phone
+}`
+
+const BOOKING_PROJECTION = `{
+  _id,
+  _createdAt,
+  _updatedAt,
+  bookingId,
+  service,
+  scheduledAt,
+  status,
+  notes,
+  createdAt,
+  "documentId": select(startsWith(_id, "drafts.") => replace(_id, "drafts.", ""), _id),
+  "isDraft": startsWith(_id, "drafts."),
+  customer->${CUSTOMER_PROJECTION}
+}`
+
+const BOOKING_QUERY = `*[_type == "booking"] | order(_updatedAt desc) ${BOOKING_PROJECTION}`
+
+const BOOKING_LISTEN_QUERY = '*[_type == "booking"]'
+
+const DEFAULT_APPOINTMENT_HOUR = 9
+
+const weekdayLabels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+const STATUS_TONES: Record<string, {background: string; color: string}> = {
+  confirmed: {background: 'rgba(34,211,238,0.12)', color: '#06b6d4'},
+  rescheduled: {background: 'rgba(252,211,77,0.12)', color: '#f59e0b'},
+  cancelled: {background: 'rgba(248,113,113,0.12)', color: '#f87171'},
+  'no-show': {background: 'rgba(239,68,68,0.12)', color: '#ef4444'},
+  completed: {background: 'rgba(34,197,94,0.12)', color: '#22c55e'},
+  snoozed: {background: 'rgba(96,165,250,0.12)', color: '#60a5fa'},
+}
+
+const TASK_QUERY = `*[_type == "calendarTask"] | order(dueAt asc) {
+  _id,
+  title,
+  status,
+  dueAt,
+  remindAt,
+  notes,
+  booking->${BOOKING_PROJECTION},
+  assignedTo->${CUSTOMER_PROJECTION}
+}`
+
+const TASK_LISTEN_QUERY = '*[_type == "calendarTask"]'
+
+type BookingQueryResult = {
+  _id: string
+  _createdAt?: string
+  _updatedAt?: string
+  documentId: string
+  isDraft: boolean
+  bookingId?: string | null
+  service?: string | null
+  scheduledAt?: string | null
+  status?: string | null
+  notes?: string | null
+  createdAt?: string | null
+  customer?: BookingCustomer | null
+}
+
+function formatDateKey(date: Date) {
+  return format(date, 'yyyy-MM-dd')
+}
+
+function getCustomerName(customer?: BookingCustomer | null) {
+  if (!customer) return 'Unassigned customer'
+  const first = customer.firstName?.trim()
+  const last = customer.lastName?.trim()
+  if (first || last) return [first, last].filter(Boolean).join(' ')
+  if (customer.name?.trim()) return customer.name.trim()
+  if (customer.email?.trim()) return customer.email.trim()
+  if (customer.phone?.trim()) return customer.phone.trim()
+  return 'Unassigned customer'
+}
+
+function normalizeBookings(docs: BookingQueryResult[]): CalendarBooking[] {
+  const byDocument = new Map<string, CalendarBooking & {sourceIsDraft?: boolean}>()
+
+  docs.forEach((doc) => {
+    const existing = byDocument.get(doc.documentId)
+    const base: CalendarBooking & {sourceIsDraft?: boolean} = existing || {
+      documentId: doc.documentId,
+      draftId: undefined,
+      publishedId: undefined,
+      bookingId: doc.bookingId ?? null,
+      service: doc.service ?? null,
+      scheduledAt: doc.scheduledAt ?? null,
+      status: doc.status ?? null,
+      notes: doc.notes ?? null,
+      createdAt: doc.createdAt ?? doc._createdAt ?? null,
+      updatedAt: doc._updatedAt ?? doc._createdAt ?? null,
+      customer: doc.customer ?? null,
+      sourceIsDraft: doc.isDraft,
+    }
+
+    if (doc.isDraft) {
+      base.draftId = doc._id
+    } else {
+      base.publishedId = doc._id
+    }
+
+    if (!existing || doc.isDraft || !base.sourceIsDraft) {
+      base.bookingId = doc.bookingId ?? null
+      base.service = doc.service ?? null
+      base.scheduledAt = doc.scheduledAt ?? null
+      base.status = doc.status ?? null
+      base.notes = doc.notes ?? null
+      base.createdAt = doc.createdAt ?? doc._createdAt ?? base.createdAt ?? null
+      base.updatedAt = doc._updatedAt ?? doc._createdAt ?? base.updatedAt ?? null
+      base.customer = doc.customer ?? null
+      base.sourceIsDraft = doc.isDraft
+    }
+
+    byDocument.set(doc.documentId, base)
+  })
+
+  return Array.from(byDocument.values()).map(({sourceIsDraft, ...record}) => record)
+}
+
+type TaskQueryResult = {
+  _id: string
+  title?: string | null
+  status?: string | null
+  dueAt?: string | null
+  remindAt?: string | null
+  notes?: string | null
+  booking?: BookingQueryResult | null
+  assignedTo?: BookingCustomer | null
+}
+
+function normalizeTasks(docs: TaskQueryResult[]): CalendarTask[] {
+  return docs.map((doc) => {
+    const booking = doc.booking ? normalizeBookings([doc.booking])[0] : null
+    return {
+      _id: doc._id,
+      title: doc.title?.trim() || 'Calendar task',
+      status: doc.status || 'pending',
+      dueAt: doc.dueAt ?? null,
+      remindAt: doc.remindAt ?? null,
+      notes: doc.notes ?? null,
+      booking,
+      assignedTo: doc.assignedTo ?? null,
+    }
+  })
+}
+
+const CalendarApp = React.forwardRef<HTMLDivElement>((_props, ref) => {
+  const client = useClient({apiVersion: '2024-10-01'})
+  const router = useRouter()
+  const {push: pushToast} = useToast()
+
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+  const [bookings, setBookings] = useState<CalendarBooking[]>([])
+  const [tasks, setTasks] = useState<CalendarTask[]>([])
+  const [currentMonth, setCurrentMonth] = useState<Date>(startOfMonth(new Date()))
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date())
+  const [hoveredDateKey, setHoveredDateKey] = useState<string | null>(null)
+  const [statusFilter, setStatusFilter] = useState<string>('all')
+  const [reschedulingId, setReschedulingId] = useState<string | null>(null)
+  const [pendingTaskIds, setPendingTaskIds] = useState<string[]>([])
+  const addPendingTask = useCallback((id: string) => {
+    setPendingTaskIds((prev) => (prev.includes(id) ? prev : [...prev, id]))
+  }, [])
+  const removePendingTask = useCallback((id: string) => {
+    setPendingTaskIds((prev) => prev.filter((item) => item !== id))
+  }, [])
+
+  const pendingTaskCreationRef = useRef<Set<string>>(new Set())
+
+  const loadCalendarData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [bookingDocs, taskDocs] = await Promise.all([
+        client.fetch<BookingQueryResult[]>(BOOKING_QUERY, {}, {perspective: 'previewDrafts'}),
+        client.fetch<TaskQueryResult[]>(TASK_QUERY, {}, {perspective: 'previewDrafts'}),
+      ])
+      setBookings(normalizeBookings(bookingDocs))
+      setTasks(normalizeTasks(taskDocs))
+    } catch (err) {
+      console.error('Failed to load booking calendar data', err)
+      setError(err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }, [client])
+
+  useEffect(() => {
+    loadCalendarData()
+  }, [loadCalendarData])
+
+  useEffect(() => {
+    const bookingSubscription = client
+      .listen(BOOKING_LISTEN_QUERY, {}, {visibility: 'query', tag: 'calendar-app'})
+      .subscribe(() => {
+        loadCalendarData()
+      })
+
+    const taskSubscription = client
+      .listen(TASK_LISTEN_QUERY, {}, {visibility: 'query', tag: 'calendar-app-tasks'})
+      .subscribe(() => {
+        loadCalendarData()
+      })
+
+    return () => {
+      bookingSubscription.unsubscribe()
+      taskSubscription.unsubscribe()
+    }
+  }, [client, loadCalendarData])
+
+  const eventsByDate = useMemo(() => {
+    const map = new Map<string, CalendarBooking[]>()
+    bookings.forEach((booking) => {
+      if (!booking.scheduledAt) return
+      try {
+        const date = parseISO(booking.scheduledAt)
+        const key = formatDateKey(date)
+        const list = map.get(key) || []
+        list.push(booking)
+        map.set(key, list)
+      } catch (err) {
+        console.warn('Failed to parse booking date', booking.scheduledAt, err)
+      }
+    })
+
+    map.forEach((list, key) => {
+      list.sort((a, b) => {
+        if (!a.scheduledAt || !b.scheduledAt) return 0
+        const aDate = parseISO(a.scheduledAt)
+        const bDate = parseISO(b.scheduledAt)
+        if (isBefore(aDate, bDate)) return -1
+        if (isBefore(bDate, aDate)) return 1
+        return 0
+      })
+      map.set(key, list)
+    })
+
+    return map
+  }, [bookings])
+
+  const bookingsById = useMemo(() => {
+    return new Map(bookings.map((booking) => [booking.documentId, booking]))
+  }, [bookings])
+
+  const tasksByBookingId = useMemo(() => {
+    const map = new Map<string, CalendarTask>()
+    tasks.forEach((task) => {
+      if (task.booking) {
+        map.set(task.booking.documentId, task)
+      }
+    })
+    return map
+  }, [tasks])
+
+  const unscheduledBookings = useMemo(
+    () => bookings.filter((booking) => !booking.scheduledAt),
+    [bookings],
+  )
+
+  const upcomingBookings = useMemo(() => {
+    const now = new Date()
+    const filtered = bookings.filter((booking) => {
+      if (!booking.scheduledAt) return false
+      try {
+        const date = parseISO(booking.scheduledAt)
+        return !isBefore(date, now)
+      } catch {
+        return false
+      }
+    })
+
+    filtered.sort((a, b) => {
+      if (!a.scheduledAt || !b.scheduledAt) return 0
+      const aDate = parseISO(a.scheduledAt)
+      const bDate = parseISO(b.scheduledAt)
+      if (isBefore(aDate, bDate)) return -1
+      if (isBefore(bDate, aDate)) return 1
+      return 0
+    })
+
+    return filtered
+  }, [bookings])
+
+  const filteredUpcoming = useMemo(() => {
+    if (statusFilter === 'all') return upcomingBookings
+    return upcomingBookings.filter((booking) => (booking.status || 'unspecified') === statusFilter)
+  }, [statusFilter, upcomingBookings])
+
+  const days = useMemo(() => {
+    const start = startOfWeek(startOfMonth(currentMonth), {weekStartsOn: 1})
+    const end = endOfWeek(endOfMonth(currentMonth), {weekStartsOn: 1})
+
+    return eachDayOfInterval({start, end}).map((date) => {
+      const key = formatDateKey(date)
+      const events = eventsByDate.get(key) || []
+      return {
+        date,
+        dateKey: key,
+        isCurrentMonth: isSameMonth(date, currentMonth),
+        isToday: isToday(date),
+        isSelected: isSameDay(date, selectedDate),
+        events,
+      }
+    })
+  }, [currentMonth, eventsByDate, selectedDate])
+
+  const selectedDateEvents = useMemo(() => {
+    const key = formatDateKey(selectedDate)
+    return eventsByDate.get(key) || []
+  }, [eventsByDate, selectedDate])
+
+  const selectedDateTasks = useMemo(() => {
+    const key = formatDateKey(selectedDate)
+    return tasks.filter((task) => {
+      const scheduled = task.booking?.scheduledAt
+      if (!scheduled) return false
+      const parsed = parseDateSafe(scheduled)
+      if (!parsed) return false
+      return formatDateKey(parsed) === key
+    })
+  }, [selectedDate, tasks])
+
+  const upcomingTaskReminders = useMemo(() => {
+    const now = new Date()
+    const items = tasks
+      .filter((task) => task.status !== 'completed')
+      .map((task) => {
+        const due = parseDateSafe(task.dueAt || task.booking?.scheduledAt || null)
+        const remind = parseDateSafe(task.remindAt)
+        return {
+          task,
+          due,
+          remind,
+          isOverdue: due ? isBefore(due, now) : false,
+        }
+      })
+      .filter((item) => item.due || item.remind)
+
+    items.sort((a, b) => {
+      const aTime = a.remind?.getTime() || a.due?.getTime() || Number.MAX_SAFE_INTEGER
+      const bTime = b.remind?.getTime() || b.due?.getTime() || Number.MAX_SAFE_INTEGER
+      return aTime - bTime
+    })
+
+    return items
+  }, [tasks])
+
+  const ensureTasksForBookings = useCallback(async () => {
+    if (!bookings.length) return
+
+    const createdSummaries: string[] = []
+    const completedSummaries: string[] = []
+    const reopenedSummaries: string[] = []
+
+    let didMutate = false
+
+    for (const booking of bookings) {
+      const existingTask = tasksByBookingId.get(booking.documentId)
+      const plan = computeTaskSyncPlan(booking, existingTask ?? null)
+
+      if (plan.shouldCreate) {
+        if (pendingTaskCreationRef.current.has(booking.documentId)) {
+          continue
+        }
+
+        pendingTaskCreationRef.current.add(booking.documentId)
+
+        try {
+          const existingCount = await client.fetch<number>(
+            'count(*[_type == "calendarTask" && references($bookingId)])',
+            {bookingId: booking.documentId},
+            {perspective: 'previewDrafts'},
+          )
+
+          if (existingCount > 0) {
+            continue
+          }
+
+          await withRetry(
+            () =>
+              client.create(
+                {
+                  _type: 'calendarTask',
+                  title: `Follow up with ${getCustomerName(booking.customer)}`,
+                  status: 'pending',
+                  dueAt: plan.dueAtIso,
+                  remindAt: plan.remindAtIso,
+                  notes: booking.notes || undefined,
+                  booking: {
+                    _type: 'reference',
+                    _ref: booking.documentId,
+                  },
+                  assignedTo: plan.assignedRef,
+                },
+                {tag: 'calendar-app-task-auto-create'},
+              ),
+            {attempts: 3, delayMs: 600},
+          )
+
+          didMutate = true
+          createdSummaries.push(getCustomerName(booking.customer))
+        } catch (err) {
+          console.error('Failed to create calendar task', err)
+          pushToast({
+            status: 'error',
+            title: 'Unable to create reminder task',
+            description: err instanceof Error ? err.message : 'An unexpected error occurred.',
+          })
+        } finally {
+          pendingTaskCreationRef.current.delete(booking.documentId)
+        }
+
+        continue
+      }
+
+      if (!existingTask) {
+        continue
+      }
+
+      const {setPayload, unsetPayload, statusChange} = plan
+
+      if (Object.keys(setPayload).length === 0 && unsetPayload.length === 0) {
+        continue
+      }
+
+      try {
+        await withRetry(() => {
+          let patchBuilder = client.patch(existingTask._id)
+          if (Object.keys(setPayload).length > 0) {
+            patchBuilder = patchBuilder.set(setPayload)
+          }
+          if (unsetPayload.length > 0) {
+            patchBuilder = patchBuilder.unset(unsetPayload)
+          }
+
+          return patchBuilder.commit({tag: 'calendar-app-task-sync'})
+        })
+
+        if (statusChange === 'complete') {
+          completedSummaries.push(getCustomerName(booking.customer))
+        } else if (statusChange === 'reopen') {
+          reopenedSummaries.push(getCustomerName(booking.customer))
+        }
+
+        didMutate = true
+      } catch (err) {
+        console.error('Failed to sync calendar task', err)
+        pushToast({
+          status: 'error',
+          title: 'Unable to update reminder task',
+          description: err instanceof Error ? err.message : 'An unexpected error occurred.',
+        })
+      }
+    }
+
+    if (didMutate) {
+      await loadCalendarData()
+    }
+
+    const summarize = (records: string[]) => {
+      if (!records.length) return ''
+      if (records.length === 1) return records[0]
+      const [first, second, ...rest] = records
+      return rest.length > 0 ? `${first}, ${second}${rest.length ? ` +${rest.length} more` : ''}` : `${first}, ${second}`
+    }
+
+    if (createdSummaries.length > 0) {
+      pushToast({
+        status: 'success',
+        title: createdSummaries.length === 1 ? 'Reminder task created' : 'Reminder tasks created',
+        description: `Scheduled follow-ups for ${summarize(createdSummaries)}.`,
+      })
+    }
+
+    if (completedSummaries.length > 0) {
+      pushToast({
+        status: 'success',
+        title: completedSummaries.length === 1 ? 'Task completed automatically' : 'Tasks completed automatically',
+        description: `Marked reminders done for ${summarize(completedSummaries)} based on booking status.`,
+      })
+    }
+
+    if (reopenedSummaries.length > 0) {
+      pushToast({
+        status: 'info',
+        title: reopenedSummaries.length === 1 ? 'Task reopened' : 'Tasks reopened',
+        description: `Reactivated follow-ups for ${summarize(reopenedSummaries)}.`,
+      })
+    }
+  }, [bookings, client, loadCalendarData, pushToast, tasksByBookingId])
+
+  useEffect(() => {
+    ensureTasksForBookings().catch((err) => {
+      console.error('Failed to ensure calendar tasks', err)
+    })
+  }, [ensureTasksForBookings])
+
+  const statusOptions = useMemo(() => {
+    const counts = new Map<string, number>()
+    bookings.forEach((booking) => {
+      const status = booking.status || 'unspecified'
+      counts.set(status, (counts.get(status) || 0) + 1)
+    })
+    const entries = Array.from(counts.entries()).sort((a, b) => a[0].localeCompare(b[0]))
+    return [{id: 'all', label: 'All', count: bookings.length}, ...entries.map(([id, count]) => ({id, label: id, count}))]
+  }, [bookings])
+
+  const handleNavigateMonth = (direction: 'previous' | 'next' | 'today') => {
+    if (direction === 'previous') {
+      const next = subMonths(currentMonth, 1)
+      setCurrentMonth(next)
+      if (!isSameMonth(selectedDate, next)) {
+        setSelectedDate(next)
+      }
+    } else if (direction === 'next') {
+      const next = addMonths(currentMonth, 1)
+      setCurrentMonth(next)
+      if (!isSameMonth(selectedDate, next)) {
+        setSelectedDate(next)
+      }
+    } else {
+      const today = new Date()
+      setCurrentMonth(startOfMonth(today))
+      setSelectedDate(today)
+    }
+  }
+
+  const handleOpenDocument = useCallback(
+    (booking: CalendarBooking) => {
+      router.navigateIntent('edit', {id: booking.documentId, type: 'booking'})
+    },
+    [router],
+  )
+
+  const handleCreateBooking = useCallback(
+    (_initialDate?: Date) => {
+      router.navigateIntent('create', {type: 'booking'})
+    },
+    [router],
+  )
+
+  const handleOpenTask = useCallback(
+    (task: CalendarTask) => {
+      router.navigateIntent('edit', {id: task._id, type: 'calendarTask'})
+    },
+    [router],
+  )
+
+  const syncBookingStatusFromTask = useCallback(
+    async (action: 'complete' | 'snooze', task: CalendarTask) => {
+      if (!task.booking) return
+
+      const nextStatus = deriveBookingStatusFromTaskAction(action, task.booking.status)
+      if (!nextStatus || task.booking.status === nextStatus) {
+        return
+      }
+
+      try {
+        await withRetry(() => {
+          const transaction = client.transaction()
+          let hasMutations = false
+
+          const patchBooking = (id?: string | null) => {
+            if (!id) return
+            transaction.patch(id, {set: {status: nextStatus}})
+            hasMutations = true
+          }
+
+          patchBooking(task.booking?.documentId)
+          patchBooking(task.booking?.draftId)
+
+          if (!hasMutations) {
+            return Promise.resolve(undefined)
+          }
+
+          return transaction.commit({tag: 'calendar-app-booking-sync'})
+        })
+
+        setBookings((prev) =>
+          prev.map((booking) =>
+            booking.documentId === task.booking?.documentId
+              ? {...booking, status: nextStatus}
+              : booking,
+          ),
+        )
+
+        setTasks((prev) =>
+          prev.map((item) =>
+            item._id === task._id
+              ? {
+                  ...item,
+                  booking: item.booking
+                    ? {
+                        ...item.booking,
+                        status: nextStatus,
+                      }
+                    : item.booking,
+                }
+              : item,
+          ),
+        )
+      } catch (err) {
+        console.error('Failed to sync booking status from task', err)
+        pushToast({
+          status: 'warning',
+          title: 'Booking status update failed',
+          description:
+            err instanceof Error
+              ? err.message
+              : 'Unable to reflect the reminder change on the booking.',
+        })
+      }
+    },
+    [client, pushToast],
+  )
+
+  const handleCompleteTask = useCallback(
+    async (task: CalendarTask) => {
+      addPendingTask(task._id)
+      try {
+        await withRetry(() =>
+          client
+            .patch(task._id, {set: {status: 'completed'}})
+            .commit({tag: 'calendar-app-task-complete'}),
+        )
+
+        const updatedTask: CalendarTask = {...task, status: 'completed'}
+
+        setTasks((prev) =>
+          prev.map((item) => (item._id === task._id ? {...item, status: 'completed'} : item)),
+        )
+
+        await syncBookingStatusFromTask('complete', updatedTask)
+
+        pushToast({
+          status: 'success',
+          title: 'Task marked complete',
+          description: `Marked "${task.title}" as completed.`,
+        })
+      } catch (err) {
+        console.error('Failed to complete calendar task', err)
+        pushToast({
+          status: 'error',
+          title: 'Unable to mark task complete',
+          description: err instanceof Error ? err.message : 'An unexpected error occurred.',
+        })
+      } finally {
+        removePendingTask(task._id)
+      }
+    },
+    [addPendingTask, client, pushToast, removePendingTask, syncBookingStatusFromTask],
+  )
+
+  const handleSnoozeTask = useCallback(
+    async (task: CalendarTask) => {
+      addPendingTask(task._id)
+      const nextReminder = computeSnoozedReminder(task)
+      const nextReminderIso = formatDateForStorage(nextReminder)
+
+      try {
+        await withRetry(() =>
+          client
+            .patch(task._id, {set: {remindAt: nextReminderIso}})
+            .commit({tag: 'calendar-app-task-snooze'}),
+        )
+
+        setTasks((prev) =>
+          prev.map((item) => (item._id === task._id ? {...item, remindAt: nextReminderIso} : item)),
+        )
+
+        await syncBookingStatusFromTask('snooze', {...task})
+
+        pushToast({
+          status: 'success',
+          title: 'Reminder snoozed',
+          description: `We will remind you ${format(nextReminder, "MMM d, h:mm a")}.`,
+        })
+      } catch (err) {
+        console.error('Failed to snooze calendar task', err)
+        pushToast({
+          status: 'error',
+          title: 'Unable to snooze reminder',
+          description: err instanceof Error ? err.message : 'An unexpected error occurred.',
+        })
+      } finally {
+        removePendingTask(task._id)
+      }
+    },
+    [addPendingTask, client, pushToast, removePendingTask, setTasks, syncBookingStatusFromTask],
+  )
+
+  const applyReschedule = useCallback(
+    async (booking: CalendarBooking, nextDate: Date | null) => {
+      const nextIso = nextDate ? formatDateForStorage(nextDate) : null
+      const currentIso = booking.scheduledAt || null
+      if (isoTimesEqual(currentIso, nextIso)) {
+        setHoveredDateKey(null)
+        return
+      }
+
+      const transaction = client.transaction()
+      let hasMutations = false
+
+      const applyPatch = (id: string) => {
+        if (!id) return
+        if (nextIso) {
+          transaction.patch(id, {set: {scheduledAt: nextIso}})
+        } else {
+          transaction.patch(id, {unset: ['scheduledAt']})
+        }
+        hasMutations = true
+      }
+
+      if (booking.publishedId) {
+        applyPatch(booking.documentId)
+      }
+
+      if (booking.draftId) {
+        applyPatch(booking.draftId)
+      }
+
+      if (!booking.publishedId && !booking.draftId) {
+        applyPatch(booking.documentId)
+      }
+
+      if (!hasMutations) {
+        return
+      }
+
+      setReschedulingId(booking.documentId)
+      try {
+        await withRetry(() => transaction.commit({tag: 'calendar-app-reschedule'}))
+        setBookings((prev) =>
+          prev.map((item) =>
+            item.documentId === booking.documentId ? {...item, scheduledAt: nextIso} : item,
+          ),
+        )
+
+        const relatedTask = tasksByBookingId.get(booking.documentId)
+        if (relatedTask) {
+          const updatedBooking: CalendarBooking = {...booking, scheduledAt: nextIso}
+          const {dueAtIso, remindAtIso} = computeTaskTiming(updatedBooking, nextDate)
+
+          try {
+            await withRetry(() =>
+              client
+                .patch(relatedTask._id, {
+                  set: {
+                    dueAt: dueAtIso,
+                    remindAt: remindAtIso,
+                  },
+                })
+                .commit({tag: 'calendar-app-task-sync'}),
+            )
+
+            setTasks((prev) =>
+              prev.map((task) =>
+                task._id === relatedTask._id
+                  ? {
+                      ...task,
+                      dueAt: dueAtIso,
+                      remindAt: remindAtIso,
+                      booking: task.booking ? {...task.booking, scheduledAt: nextIso} : task.booking,
+                    }
+                  : task,
+              ),
+            )
+
+            pushToast({
+              status: 'success',
+              title: 'Reminder updated',
+              description: `Task timing synced to ${format(nextDate ?? new Date(dueAtIso), "MMM d, h:mm a")}.`,
+            })
+          } catch (taskErr) {
+            console.error('Failed to update calendar task timing', taskErr)
+          }
+        }
+
+        pushToast({
+          status: 'success',
+          title: nextIso ? 'Appointment rescheduled' : 'Appointment unscheduled',
+          description: nextIso
+            ? format(parseISO(nextIso), "MMMM d, yyyy 'at' h:mmaaa")
+            : 'This appointment is now unscheduled.',
+        })
+      } catch (err) {
+        console.error('Failed to reschedule booking', err)
+        pushToast({
+          status: 'error',
+          title: 'Unable to update appointment',
+          description: err instanceof Error ? err.message : 'An unexpected error occurred.',
+        })
+        loadCalendarData()
+      } finally {
+        setReschedulingId(null)
+        setHoveredDateKey(null)
+      }
+    },
+    [client, loadCalendarData, pushToast, setTasks, tasksByBookingId],
+  )
+
+  const handleDropOnDate = useCallback(
+    (dateKey: string, event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      setHoveredDateKey(null)
+      const documentId = event.dataTransfer.getData('application/x-calendar-doc-id')
+      if (!documentId) return
+      const booking = bookingsById.get(documentId)
+      if (!booking) return
+
+      const originalIso =
+        event.dataTransfer.getData('application/x-calendar-original-start') || booking.scheduledAt || ''
+
+      const [year, month, day] = dateKey.split('-').map((segment) => parseInt(segment, 10))
+      const base = new Date(year, month - 1, day)
+      if (originalIso) {
+        const originalDate = parseISO(originalIso)
+        base.setHours(
+          originalDate.getHours(),
+          originalDate.getMinutes(),
+          originalDate.getSeconds(),
+          originalDate.getMilliseconds(),
+        )
+      } else {
+        base.setHours(DEFAULT_APPOINTMENT_HOUR, 0, 0, 0)
+      }
+
+      applyReschedule(booking, base)
+    },
+    [applyReschedule, bookingsById],
+  )
+
+  const handleDropUnscheduled = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      const documentId = event.dataTransfer.getData('application/x-calendar-doc-id')
+      if (!documentId) return
+      const booking = bookingsById.get(documentId)
+      if (!booking) return
+      applyReschedule(booking, null)
+    },
+    [applyReschedule, bookingsById],
+  )
+
+  const handleDragStart = (event: React.DragEvent<HTMLElement>, booking: CalendarBooking) => {
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('application/x-calendar-doc-id', booking.documentId)
+    if (booking.scheduledAt) {
+      event.dataTransfer.setData('application/x-calendar-original-start', booking.scheduledAt)
+    }
+  }
+
+  const handleDragEnter = (dateKey: string) => setHoveredDateKey(dateKey)
+  const handleDragLeave = (event: React.DragEvent<HTMLDivElement>, dateKey: string) => {
+    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+      setHoveredDateKey((prev) => (prev === dateKey ? null : prev))
+    }
+  }
+
+  const selectedDayLabel = format(selectedDate, 'MMMM do, yyyy')
+  const currentMonthLabel = format(currentMonth, 'MMMM yyyy')
+
+  return (
+    <div ref={ref} className="studio-page">
+      <header className="studio-header">
+        <div className="studio-header__inner">
+          <div className="studio-header__titles">
+            <h1 className="studio-header__title">Appointments calendar</h1>
+            <p className="studio-header__description">
+              Use the calendar to monitor service bookings and general meetings. Drag and drop appointments
+              to reschedule.
+            </p>
+          </div>
+          <Flex gap={2} align="center" wrap="wrap">
+            <Button
+              icon={AddIcon}
+              mode="ghost"
+              text="New appointment"
+              tone="primary"
+              onClick={() => handleCreateBooking(selectedDate)}
+            />
+            <Button
+              icon={RefreshIcon}
+              mode="ghost"
+              text="Refresh"
+              tone="default"
+              onClick={loadCalendarData}
+              disabled={loading}
+            />
+          </Flex>
+        </div>
+        <Card padding={[3, 4]} radius={3} shadow={1} tone="transparent" className="mt-6 w-full">
+          <Flex direction={['column', 'column', 'row']} align={['stretch', 'stretch', 'center']} gap={3} wrap="wrap">
+            <Flex gap={2} align="center">
+              <Button
+                icon={ChevronLeftIcon}
+                mode="ghost"
+                tone="default"
+                aria-label="Previous month"
+                onClick={() => handleNavigateMonth('previous')}
+              />
+              <Heading as="h2" size={2} style={{margin: 0}}>
+                {currentMonthLabel}
+              </Heading>
+              <Button
+                icon={ChevronRightIcon}
+                mode="ghost"
+                tone="default"
+                aria-label="Next month"
+                onClick={() => handleNavigateMonth('next')}
+              />
+              <Button mode="bleed" text="Today" onClick={() => handleNavigateMonth('today')} />
+            </Flex>
+            <Flex gap={2} wrap="wrap">
+              {statusOptions.map((option) => {
+                const isActive = statusFilter === option.id
+                return (
+                  <Button
+                    key={option.id}
+                    mode={isActive ? 'default' : 'ghost'}
+                    tone={isActive ? 'primary' : 'default'}
+                    onClick={() => setStatusFilter(option.id)}
+                    text={`${option.label} (${option.count})`}
+                  />
+                )
+              })}
+            </Flex>
+          </Flex>
+        </Card>
+      </header>
+
+      <main className="studio-content">
+        {loading && (
+          <Card padding={4} radius={3} shadow={1} tone="transparent">
+            <Flex gap={3} align="center">
+              <Spinner />
+              <Text size={2}>Loading appointments…</Text>
+            </Flex>
+          </Card>
+        )}
+
+        {error && (
+          <Card padding={4} radius={3} shadow={1} tone="caution">
+            <Stack space={3}>
+              <Heading size={1}>Unable to load calendar</Heading>
+              <Text size={2}>{error}</Text>
+              <Button text="Try again" tone="primary" onClick={loadCalendarData} />
+            </Stack>
+          </Card>
+        )}
+
+        {!loading && !error && (
+          <Flex direction={['column', 'column', 'row']} gap={4}>
+            <Box flex={2} minWidth={0}>
+              <Card padding={[3, 4]} radius={3} shadow={1} tone="transparent">
+                <Stack space={4}>
+                  <div
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: 'repeat(7, minmax(0, 1fr))',
+                      gap: '0.5rem',
+                      fontSize: 12,
+                      textTransform: 'uppercase',
+                      color: '#94a3b8',
+                      letterSpacing: '0.08em',
+                    }}
+                  >
+                    {weekdayLabels.map((label) => (
+                      <span key={label} style={{textAlign: 'center'}}>
+                        {label}
+                      </span>
+                    ))}
+                  </div>
+
+                  <div
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: 'repeat(7, minmax(0, 1fr))',
+                      gap: '0.75rem',
+                    }}
+                  >
+                    {days.map((day) => {
+                      const isHovered = hoveredDateKey === day.dateKey
+                      const visibleEvents =
+                        statusFilter === 'all'
+                          ? day.events
+                          : day.events.filter((event) => (event.status || 'unspecified') === statusFilter)
+                      const dayTasks = day.events
+                        .map((event) => tasksByBookingId.get(event.documentId))
+                        .filter((task): task is CalendarTask => Boolean(task))
+
+                      const dayTaskCount = dayTasks.length
+                      const dayTaskVariant = dayTasks.length ? summarizeTaskBadges(dayTasks) : null
+                      const dayTaskStyles = dayTaskVariant ? TASK_BADGE_STYLES[dayTaskVariant] : null
+
+                      return (
+                        <Card
+                          key={day.dateKey}
+                          padding={3}
+                          radius={3}
+                          shadow={isHovered ? 2 : 1}
+                          tone="transparent"
+                          style={{
+                            minHeight: 150,
+                            background: day.isSelected
+                              ? 'rgba(59,130,246,0.14)'
+                              : day.isCurrentMonth
+                              ? 'rgba(15,23,42,0.55)'
+                              : 'rgba(15,23,42,0.25)',
+                            border: isHovered
+                              ? '1px solid rgba(59,130,246,0.5)'
+                              : day.isToday
+                              ? '1px solid rgba(148,163,184,0.5)'
+                              : '1px solid transparent',
+                            transition: 'border-color 0.15s ease, box-shadow 0.15s ease',
+                          }}
+                          onDragOver={(event) => {
+                            event.preventDefault()
+                            event.dataTransfer.dropEffect = 'move'
+                          }}
+                          onDragEnter={() => handleDragEnter(day.dateKey)}
+                          onDragLeave={(event) => handleDragLeave(event, day.dateKey)}
+                          onDrop={(event) => handleDropOnDate(day.dateKey, event)}
+                        >
+                          <Stack space={3}>
+                            <Flex align="center" justify="space-between" gap={2} wrap="wrap">
+                              <Button
+                                mode="bleed"
+                                tone="default"
+                                text={format(day.date, 'd')}
+                                fontSize={2}
+                                onClick={() => setSelectedDate(day.date)}
+                                style={{
+                                  color: day.isToday ? '#f8fafc' : undefined,
+                                  fontWeight: day.isToday ? 600 : 500,
+                                }}
+                              />
+                              <Inline space={2} style={{alignItems: 'center'}}>
+                                {dayTaskCount > 0 && (
+                                  <Badge
+                                    mode="outline"
+                                    tone={dayTaskStyles?.tone}
+                                    style={{
+                                      borderColor: dayTaskStyles?.borderColor,
+                                      background: dayTaskStyles?.background,
+                                      color: dayTaskStyles?.textColor,
+                                      textTransform: 'capitalize',
+                                    }}
+                                  >
+                                    <Flex align="center" gap={2}>
+                                      <BellIcon style={{width: 12, height: 12}} />
+                                      <Text size={0}>{dayTaskCount}</Text>
+                                      {dayTaskStyles && <Text size={0}>{dayTaskStyles.label}</Text>}
+                                    </Flex>
+                                  </Badge>
+                                )}
+                                <Button
+                                  icon={AddIcon}
+                                  mode="bleed"
+                                  tone="default"
+                                  aria-label="Create appointment"
+                                  onClick={() => handleCreateBooking(day.date)}
+                                />
+                              </Inline>
+                            </Flex>
+
+                            <Stack space={2}>
+                              {visibleEvents.length === 0 ? (
+                                <Text size={1} muted>
+                                  {day.events.length === 0 ? 'Available' : 'No events match this filter'}
+                                </Text>
+                              ) : (
+                                visibleEvents.map((event) => {
+                                  const tone = event.status ? STATUS_TONES[event.status] : undefined
+                                  const isUpdating = reschedulingId === event.documentId
+                                  const associatedTask = tasksByBookingId.get(event.documentId)
+                                  const taskBadge = associatedTask ? resolveTaskBadge(associatedTask) : null
+                                  const taskBadgeStyles = taskBadge
+                                    ? TASK_BADGE_STYLES[taskBadge.variant]
+                                    : null
+                                  const matchesFilter =
+                                    statusFilter === 'all' || (event.status || 'unspecified') === statusFilter
+
+                                  return (
+                                    <Card
+                                      key={event.documentId}
+                                      padding={2}
+                                      radius={2}
+                                      shadow={1}
+                                      draggable
+                                      onDragStart={(dragEvent) => handleDragStart(dragEvent, event)}
+                                      onDoubleClick={() => handleOpenDocument(event)}
+                                      style={{
+                                        cursor: 'grab',
+                                        background: tone?.background || 'rgba(15,23,42,0.85)',
+                                        color: tone?.color || '#e2e8f0',
+                                        border: isUpdating
+                                          ? '1px dashed rgba(96,165,250,0.6)'
+                                          : '1px solid rgba(15,23,42,0.1)',
+                                        opacity: matchesFilter ? 1 : 0.65,
+                                      }}
+                                    >
+                                      <Stack space={1}>
+                                        <Flex align="center" justify="space-between" gap={2}>
+                                          <Text size={1} weight="semibold">
+                                            {event.scheduledAt
+                                              ? format(parseISO(event.scheduledAt), 'h:mm a')
+                                              : 'Unscheduled'}
+                                          </Text>
+                                          <Inline space={2} style={{alignItems: 'center'}}>
+                                            {associatedTask && taskBadgeStyles && (
+                                              <Tooltip
+                                                portal
+                                                content={
+                                                  <Box padding={2} style={{maxWidth: 220}}>
+                                                    <Text size={1}>
+                                                      {TASK_BADGE_DESCRIPTIONS[variant]}
+                                                    </Text>
+                                                  </Box>
+                                                }
+                                              >
+                                                <Badge
+                                                  tone={taskBadgeStyles.tone}
+                                                  style={{
+                                                    borderColor: taskBadgeStyles.borderColor,
+                                                    background: taskBadgeStyles.background,
+                                                    color: taskBadgeStyles.textColor,
+                                                    textTransform: 'capitalize',
+                                                  }}
+                                                >
+                                                  <Flex align="center" gap={1}>
+                                                    <BellIcon style={{width: 12, height: 12}} />
+                                                    <Text size={0}>{taskBadgeStyles.label}</Text>
+                                                  </Flex>
+                                                </Badge>
+                                              </Tooltip>
+                                            )}
+                                            <Button
+                                              icon={EditIcon}
+                                              mode="bleed"
+                                              tone="default"
+                                              aria-label="Open appointment"
+                                              onClick={() => handleOpenDocument(event)}
+                                            />
+                                          </Inline>
+                                        </Flex>
+                                        <Text size={1}>{getCustomerName(event.customer)}</Text>
+                                        {event.service && (
+                                          <Text size={0} muted>
+                                            {event.service}
+                                          </Text>
+                                        )}
+                                        {event.status && (
+                                          <Badge
+                                            mode="outline"
+                                            tone="default"
+                                            style={{
+                                              borderColor: tone?.color || 'rgba(148,163,184,0.4)',
+                                              color: tone?.color || '#f1f5f9',
+                                            }}
+                                          >
+                                            {event.status}
+                                          </Badge>
+                                        )}
+                                      </Stack>
+                                    </Card>
+                                  )
+                                })
+                              )}
+                            </Stack>
+                          </Stack>
+                        </Card>
+                      )
+                    })}
+                  </div>
+                </Stack>
+              </Card>
+            </Box>
+
+            <Box flex={1} minWidth={0}>
+              <Stack space={4}>
+                <Card padding={[3, 4]} radius={3} shadow={1} tone="transparent">
+                  <Stack space={4}>
+                    <Flex align={['flex-start', 'center']} justify="space-between" wrap="wrap" gap={2}>
+                      <Heading size={1}>{selectedDayLabel}</Heading>
+                      <Button
+                        icon={AddIcon}
+                        mode="ghost"
+                        tone="primary"
+                        text="New appointment"
+                        onClick={() => handleCreateBooking(selectedDate)}
+                      />
+                    </Flex>
+                    <Stack space={3}>
+                      <Heading size={1}>Appointments</Heading>
+                      {selectedDateEvents.length === 0 ? (
+                        <Text size={1} muted>No appointments for this day yet.</Text>
+                      ) : (
+                        <Stack space={3}>
+                          {selectedDateEvents.map((event) => {
+                            const tone = event.status ? STATUS_TONES[event.status] : undefined
+                            const isUpdating = reschedulingId === event.documentId
+                            return (
+                              <Card
+                                key={event.documentId}
+                                padding={3}
+                                radius={2}
+                                shadow={1}
+                                style={{
+                                  background: 'rgba(15,23,42,0.85)',
+                                  border: isUpdating
+                                    ? '1px dashed rgba(96,165,250,0.6)'
+                                    : '1px solid rgba(15,23,42,0.2)',
+                                }}
+                              >
+                                <Stack space={2}>
+                                  <Flex align="center" justify="space-between">
+                                    <Text size={1} weight="semibold">
+                                      {event.scheduledAt
+                                        ? format(parseISO(event.scheduledAt), 'h:mm a')
+                                        : 'Unscheduled'}
+                                    </Text>
+                                    {event.status && (
+                                      <Badge
+                                        tone="default"
+                                        style={{
+                                          backgroundColor: tone?.background || 'rgba(148,163,184,0.15)',
+                                          color: tone?.color || '#e2e8f0',
+                                        }}
+                                      >
+                                        {event.status}
+                                      </Badge>
+                                    )}
+                                  </Flex>
+                                  <Text size={1}>{getCustomerName(event.customer)}</Text>
+                                  {event.service && (
+                                    <Text size={0} muted>
+                                      {event.service}
+                                    </Text>
+                                  )}
+                                  <Inline space={2}>
+                                    <Button text="Open" tone="primary" mode="ghost" onClick={() => handleOpenDocument(event)} />
+                                    <Button
+                                      text="Reschedule"
+                                      mode="ghost"
+                                      onClick={() => {
+                                        if (!event.scheduledAt) return
+                                        const date = parseISO(event.scheduledAt)
+                                        setSelectedDate(date)
+                                        setCurrentMonth(startOfMonth(date))
+                                      }}
+                                    />
+                                  </Inline>
+                                </Stack>
+                              </Card>
+                            )
+                          })}
+                        </Stack>
+                      )}
+                    </Stack>
+                    <Stack space={3}>
+                      <Flex align={['flex-start', 'center']} justify="space-between" gap={2} wrap="wrap">
+                        <Flex align="center" gap={2}>
+                          <BellIcon />
+                          <Heading size={1}>Tasks & reminders</Heading>
+                        </Flex>
+                        {pendingTaskIds.length > 0 && (
+                          <Inline space={2} style={{alignItems: 'center', display: 'flex'}}>
+                            <Spinner size={1} />
+                            <Text size={0} muted>
+                              Saving reminder updates…
+                            </Text>
+                          </Inline>
+                        )}
+                      </Flex>
+                      {selectedDateTasks.length === 0 ? (
+                        <Text size={1} muted>No active reminders for this day.</Text>
+                      ) : (
+                        <Stack space={3}>
+                          {selectedDateTasks.map((task) => {
+                            const {variant, due, remind} = resolveTaskBadge(task)
+                            const badgeStyles = TASK_BADGE_STYLES[variant]
+                            const dueDate = due || parseDateSafe(task.booking?.scheduledAt || null)
+                            const remindDate = remind
+                            const isCompleted = variant === 'completed'
+                            const isSaving = pendingTaskIds.includes(task._id)
+                            return (
+                              <Card
+                                key={task._id}
+                                padding={3}
+                                radius={2}
+                                shadow={1}
+                                style={{
+                                  background: isCompleted ? 'rgba(34,197,94,0.08)' : 'rgba(15,23,42,0.8)',
+                                  opacity: isCompleted ? 0.85 : 1,
+                                }}
+                              >
+                                <Stack space={2}>
+                                  <Flex align="center" justify="space-between">
+                                    <Text size={1} weight="semibold">{task.title}</Text>
+                                    <Tooltip
+                                      portal
+                                      content={
+                                        <Box padding={2} style={{maxWidth: 220}}>
+                                          <Text size={1}>{TASK_BADGE_DESCRIPTIONS[variant]}</Text>
+                                        </Box>
+                                      }
+                                    >
+                                      <Badge
+                                        tone={badgeStyles.tone}
+                                        style={{
+                                          borderColor: badgeStyles.borderColor,
+                                          background: badgeStyles.background,
+                                          color: badgeStyles.textColor,
+                                          textTransform: 'capitalize',
+                                        }}
+                                      >
+                                        {badgeStyles.label}
+                                      </Badge>
+                                    </Tooltip>
+                                  </Flex>
+                                  {dueDate ? (
+                                    <Text size={0} muted>
+                                      Due {format(dueDate, 'MMM d, h:mm a')} · {formatDistanceToNow(dueDate, {addSuffix: true})}
+                                    </Text>
+                                  ) : (
+                                    <Text size={0} muted>No due date set</Text>
+                                  )}
+                                  {remindDate && (
+                                    <Text size={0} muted>
+                                      Reminder {formatDistanceToNow(remindDate, {addSuffix: true})}
+                                    </Text>
+                                  )}
+                                  {task.booking && (
+                                    <Text size={0} muted>
+                                      Linked booking: {getCustomerName(task.booking.customer)}
+                                    </Text>
+                                  )}
+                                  <Inline space={2}>
+                                    <Button
+                                      text="Open task"
+                                      mode="ghost"
+                                      tone="primary"
+                                      onClick={() => handleOpenTask(task)}
+                                      disabled={isSaving}
+                                    />
+                                    {variant !== 'completed' && (
+                                      <>
+                                        <Button
+                                          text="Mark complete"
+                                          mode="ghost"
+                                          onClick={() => handleCompleteTask(task)}
+                                          disabled={isSaving}
+                                          loading={isSaving}
+                                        />
+                                        <Button
+                                          text="Snooze"
+                                          mode="ghost"
+                                          tone="default"
+                                          onClick={() => handleSnoozeTask(task)}
+                                          disabled={isSaving}
+                                          loading={isSaving}
+                                        />
+                                      </>
+                                    )}
+                                  </Inline>
+                                </Stack>
+                              </Card>
+                            )
+                          })}
+                        </Stack>
+                      )}
+                    </Stack>
+                  </Stack>
+                </Card>
+
+                <Card padding={[3, 4]} radius={3} shadow={1} tone="transparent">
+                  <Stack space={3}>
+                    <Flex align="center" gap={2}>
+                      <BellIcon />
+                      <Heading size={1}>Upcoming reminders</Heading>
+                    </Flex>
+                    {upcomingTaskReminders.length === 0 ? (
+                      <Text size={1} muted>No upcoming reminders.</Text>
+                    ) : (
+                      <Stack space={3}>
+                        {upcomingTaskReminders.slice(0, 8).map(({task, due, remind}) => {
+                          const {variant} = resolveTaskBadge(task)
+                          const badgeStyles = TASK_BADGE_STYLES[variant]
+                          const isSaving = pendingTaskIds.includes(task._id)
+                          return (
+                          <Card
+                            key={`reminder-${task._id}`}
+                            padding={3}
+                            radius={2}
+                            shadow={1}
+                            style={{background: 'rgba(15,23,42,0.8)'}}
+                          >
+                            <Stack space={1}>
+                              <Flex align="center" justify="space-between">
+                                <Text size={1} weight="semibold">{task.title}</Text>
+                                <Tooltip
+                                  portal
+                                  content={
+                                    <Box padding={2} style={{maxWidth: 220}}>
+                                      <Text size={1}>{TASK_BADGE_DESCRIPTIONS[variant]}</Text>
+                                    </Box>
+                                  }
+                                >
+                                  <Badge
+                                    tone={badgeStyles.tone}
+                                    style={{
+                                      borderColor: badgeStyles.borderColor,
+                                      background: badgeStyles.background,
+                                      color: badgeStyles.textColor,
+                                      textTransform: 'capitalize',
+                                    }}
+                                  >
+                                    {badgeStyles.label}
+                                  </Badge>
+                                </Tooltip>
+                              </Flex>
+                              <Text size={0} muted>
+                                {remind
+                                  ? `Reminder ${formatDistanceToNow(remind, {addSuffix: true})}`
+                                  : 'Reminder scheduled'}
+                              </Text>
+                              {due && (
+                                <Text size={0} muted>
+                                  Due {format(due, 'MMM d, h:mm a')}
+                                </Text>
+                              )}
+                              <Inline space={2}>
+                                <Button
+                                  text="Open"
+                                  mode="ghost"
+                                  tone="primary"
+                                  onClick={() => handleOpenTask(task)}
+                                  disabled={isSaving}
+                                />
+                                <Button
+                                  text="Complete"
+                                  mode="ghost"
+                                  onClick={() => handleCompleteTask(task)}
+                                  disabled={isSaving}
+                                  loading={isSaving}
+                                />
+                                {variant !== 'completed' && (
+                                  <Button
+                                    text="Snooze"
+                                    mode="ghost"
+                                    tone="default"
+                                    onClick={() => handleSnoozeTask(task)}
+                                    disabled={isSaving}
+                                    loading={isSaving}
+                                  />
+                                )}
+                              </Inline>
+                            </Stack>
+                          </Card>
+                        )})}
+                      </Stack>
+                    )}
+                  </Stack>
+                </Card>
+
+                <Card padding={[3, 4]} radius={3} shadow={1} tone="transparent">
+                  <Stack space={3}>
+                    <Heading size={1}>Upcoming appointments</Heading>
+                    {filteredUpcoming.length === 0 ? (
+                      <Text size={1} muted>No appointments match the selected filter.</Text>
+                    ) : (
+                      <Stack space={3}>
+                        {filteredUpcoming.slice(0, 15).map((event) => (
+                          <Card
+                            key={`upcoming-${event.documentId}`}
+                            padding={3}
+                            radius={2}
+                            shadow={1}
+                            style={{background: 'rgba(15,23,42,0.85)'}}
+                          >
+                            <Stack space={2}>
+                              <Flex align="center" justify="space-between">
+                                <Text size={1} weight="semibold">
+                                  {event.scheduledAt
+                                    ? format(parseISO(event.scheduledAt), 'MMM d, h:mm a')
+                                    : 'Unscheduled'}
+                                </Text>
+                                <Text size={0} muted>
+                                  {event.scheduledAt
+                                    ? formatDistanceToNow(parseISO(event.scheduledAt), {addSuffix: true})
+                                    : ''}
+                                </Text>
+                              </Flex>
+                              <Text size={1}>{getCustomerName(event.customer)}</Text>
+                              {event.service && (
+                                <Text size={0} muted>
+                                  {event.service}
+                                </Text>
+                              )}
+                              <Inline space={2}>
+                                <Button text="Open" mode="ghost" tone="primary" onClick={() => handleOpenDocument(event)} />
+                                <Button
+                                  text="Focus day"
+                                  mode="ghost"
+                                  onClick={() => {
+                                    if (!event.scheduledAt) return
+                                    const date = parseISO(event.scheduledAt)
+                                    setSelectedDate(date)
+                                    setCurrentMonth(startOfMonth(date))
+                                  }}
+                                />
+                              </Inline>
+                            </Stack>
+                          </Card>
+                        ))}
+                      </Stack>
+                    )}
+                  </Stack>
+                </Card>
+
+                <Card
+                  padding={[3, 4]}
+                  radius={3}
+                  shadow={1}
+                  tone="transparent"
+                  onDragOver={(event) => {
+                    event.preventDefault()
+                    event.dataTransfer.dropEffect = 'move'
+                  }}
+                  onDrop={handleDropUnscheduled}
+                >
+                  <Stack space={3}>
+                    <Heading size={1}>Unscheduled queue</Heading>
+                    <Text size={0} muted>
+                      Drop any appointment here to remove it from the calendar. Drag items from this list onto a
+                      day to schedule them.
+                    </Text>
+                    {unscheduledBookings.length === 0 ? (
+                      <Text size={1} muted>Nothing waiting. Create a new appointment to get started.</Text>
+                    ) : (
+                      <Stack space={3}>
+                        {unscheduledBookings.map((event) => (
+                          <Card
+                            key={`unscheduled-${event.documentId}`}
+                            padding={3}
+                            radius={2}
+                            shadow={1}
+                            draggable
+                            onDragStart={(dragEvent) => handleDragStart(dragEvent, event)}
+                            style={{background: 'rgba(15,23,42,0.8)', cursor: 'grab'}}
+                          >
+                            <Stack space={2}>
+                              <Text size={1} weight="semibold">{getCustomerName(event.customer)}</Text>
+                              {event.service && (
+                                <Text size={0} muted>
+                                  {event.service}
+                                </Text>
+                              )}
+                              <Inline space={2}>
+                                <Button text="Open" mode="ghost" tone="primary" onClick={() => handleOpenDocument(event)} />
+                                <Button
+                                  text="Schedule"
+                                  mode="ghost"
+                                  onClick={() => {
+                                    const baseDate = new Date()
+                                    setSelectedDate(baseDate)
+                                    setCurrentMonth(startOfMonth(baseDate))
+                                  }}
+                                />
+                              </Inline>
+                            </Stack>
+                          </Card>
+                        ))}
+                      </Stack>
+                    )}
+                  </Stack>
+                </Card>
+              </Stack>
+            </Box>
+          </Flex>
+        )}
+      </main>
+    </div>
+  )
+})
+
+CalendarApp.displayName = 'CalendarApp'
+
+export default CalendarApp

--- a/packages/sanity-config/src/apps/calendar/__tests__/shared.test.ts
+++ b/packages/sanity-config/src/apps/calendar/__tests__/shared.test.ts
@@ -1,0 +1,98 @@
+import {describe, expect, it} from 'vitest'
+import {
+  CalendarBooking,
+  CalendarTask,
+  computeSnoozedReminder,
+  computeTaskSyncPlan,
+  deriveBookingStatusFromTaskAction,
+  formatDateForStorage,
+  parseDateSafe,
+  TASK_SNOOZE_MINUTES,
+} from '../shared'
+
+describe('calendar shared utilities', () => {
+  it('plans task creation with aligned due and reminder dates', () => {
+    const scheduled = formatDateForStorage(new Date(Date.now() + 2 * 60 * 60 * 1000))
+    const booking: CalendarBooking = {
+      documentId: 'booking-1',
+      bookingId: null,
+      service: null,
+      scheduledAt: scheduled,
+      status: 'confirmed',
+      notes: null,
+      createdAt: null,
+      updatedAt: null,
+      customer: null,
+    }
+
+    const plan = computeTaskSyncPlan(booking, null)
+
+    expect(plan.shouldCreate).toBe(true)
+    const due = parseDateSafe(plan.dueAtIso)
+    const remind = parseDateSafe(plan.remindAtIso)
+
+    expect(due?.toISOString()).toEqual(parseDateSafe(scheduled)?.toISOString())
+    expect(remind && due ? remind.getTime() <= due.getTime() : false).toBe(true)
+  })
+
+  it('flags existing tasks for completion sync when bookings are completed', () => {
+    const now = new Date()
+    const scheduled = formatDateForStorage(new Date(now.getTime() + 45 * 60 * 1000))
+    const booking: CalendarBooking = {
+      documentId: 'booking-2',
+      bookingId: null,
+      service: null,
+      scheduledAt: scheduled,
+      status: 'completed',
+      notes: null,
+      createdAt: null,
+      updatedAt: null,
+      customer: null,
+    }
+
+    const existingTask: CalendarTask = {
+      _id: 'task-1',
+      title: 'Follow up',
+      status: 'pending',
+      dueAt: formatDateForStorage(now),
+      remindAt: formatDateForStorage(now),
+      notes: null,
+      booking,
+      assignedTo: null,
+    }
+
+    const plan = computeTaskSyncPlan(booking, existingTask)
+
+    expect(plan.shouldCreate).toBe(false)
+    expect(plan.statusChange).toBe('complete')
+    expect(plan.setPayload.status).toBe('completed')
+  })
+
+  it('computes snoozed reminders without exceeding due time', () => {
+    const now = new Date()
+    const due = new Date(now.getTime() + 30 * 60 * 1000)
+    const remind = new Date(now.getTime() + 10 * 60 * 1000)
+
+    const task: CalendarTask = {
+      _id: 'task-2',
+      title: 'Reminder',
+      status: 'pending',
+      dueAt: formatDateForStorage(due),
+      remindAt: formatDateForStorage(remind),
+      notes: null,
+      booking: null,
+      assignedTo: null,
+    }
+
+    const next = computeSnoozedReminder(task, {now, snoozeMinutes: TASK_SNOOZE_MINUTES})
+
+    expect(next.getTime()).toBeGreaterThanOrEqual(now.getTime())
+    expect(next.getTime()).toBeLessThanOrEqual(due.getTime())
+  })
+
+  it('derives booking statuses for dashboard quick actions', () => {
+    expect(deriveBookingStatusFromTaskAction('complete', 'confirmed')).toBe('completed')
+    expect(deriveBookingStatusFromTaskAction('snooze', 'confirmed')).toBe('snoozed')
+    expect(deriveBookingStatusFromTaskAction('snooze', 'cancelled')).toBe('cancelled')
+  })
+})

--- a/packages/sanity-config/src/apps/calendar/index.ts
+++ b/packages/sanity-config/src/apps/calendar/index.ts
@@ -1,0 +1,18 @@
+import {CalendarIcon} from '@sanity/icons'
+import {definePlugin} from 'sanity'
+
+import CalendarApp from './CalendarApp'
+
+export const calendarApp = definePlugin({
+  name: 'fas-calendar-app',
+  tools: [
+    {
+      name: 'calendar-app',
+      title: 'Appointments',
+      icon: CalendarIcon,
+      component: CalendarApp,
+    },
+  ],
+})
+
+export default calendarApp

--- a/packages/sanity-config/src/apps/calendar/shared.ts
+++ b/packages/sanity-config/src/apps/calendar/shared.ts
@@ -1,0 +1,319 @@
+import {addMinutes, format, isBefore, parseISO} from 'date-fns'
+
+export type BookingCustomer = {
+  _id?: string | null
+  firstName?: string | null
+  lastName?: string | null
+  name?: string | null
+  email?: string | null
+  phone?: string | null
+}
+
+export type CalendarBooking = {
+  documentId: string
+  draftId?: string
+  publishedId?: string
+  bookingId?: string | null
+  service?: string | null
+  scheduledAt?: string | null
+  status?: string | null
+  notes?: string | null
+  createdAt?: string | null
+  updatedAt?: string | null
+  customer?: BookingCustomer | null
+}
+
+export type CalendarTask = {
+  _id: string
+  title: string
+  status: string
+  dueAt?: string | null
+  remindAt?: string | null
+  notes?: string | null
+  booking?: CalendarBooking | null
+  assignedTo?: BookingCustomer | null
+}
+
+export const TASK_SNOOZE_MINUTES = 60
+
+export const DATE_STORAGE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssxxx"
+
+export const TASK_BADGE_STYLES = {
+  overdue: {
+    tone: 'critical' as const,
+    label: 'Overdue',
+    background: 'rgba(248,113,113,0.16)',
+    borderColor: 'rgba(248,113,113,0.45)',
+    textColor: '#fca5a5',
+  },
+  upcoming: {
+    tone: 'caution' as const,
+    label: 'Upcoming',
+    background: 'rgba(252,211,77,0.18)',
+    borderColor: 'rgba(251,191,36,0.45)',
+    textColor: '#fbbf24',
+  },
+  scheduled: {
+    tone: 'primary' as const,
+    label: 'Scheduled',
+    background: 'rgba(96,165,250,0.18)',
+    borderColor: 'rgba(96,165,250,0.45)',
+    textColor: '#bfdbfe',
+  },
+  completed: {
+    tone: 'positive' as const,
+    label: 'Completed',
+    background: 'rgba(34,197,94,0.18)',
+    borderColor: 'rgba(74,222,128,0.45)',
+    textColor: '#86efac',
+  },
+}
+
+export const TASK_BADGE_DESCRIPTIONS: Record<TaskBadgeVariant, string> = {
+  overdue: 'This reminder is overdue and needs attention right away.',
+  upcoming: 'Scheduled soon — happening within the next day.',
+  scheduled: 'Scheduled with plenty of time before it is due.',
+  completed: 'Completed and no further action is needed.',
+}
+
+export type TaskBadgeVariant = keyof typeof TASK_BADGE_STYLES
+
+export const BOOKING_COMPLETED_STATUSES = new Set(['completed', 'cancelled', 'no-show'])
+
+export function parseDateSafe(value?: string | null) {
+  if (!value) return null
+  try {
+    return parseISO(value)
+  } catch (err) {
+    console.warn('Failed to parse date value', value, err)
+    return null
+  }
+}
+
+export function formatDateForStorage(date: Date) {
+  return format(date, DATE_STORAGE_FORMAT)
+}
+
+export function isoTimesEqual(a?: string | null, b?: string | null) {
+  if (!a && !b) return true
+  if (!a || !b) return false
+  const parsedA = parseDateSafe(a)
+  const parsedB = parseDateSafe(b)
+  if (!parsedA || !parsedB) return a === b
+  return parsedA.getTime() === parsedB.getTime()
+}
+
+export function computeTaskTiming(booking: CalendarBooking, overrideDate?: Date | null) {
+  const baseDate =
+    overrideDate || parseDateSafe(booking.scheduledAt) || parseDateSafe(booking.createdAt) || new Date()
+
+  const dueAtIso = formatDateForStorage(baseDate)
+
+  let remindDate = new Date(baseDate.getTime() - 1000 * 60 * 60)
+  const now = new Date()
+  if (remindDate < now) {
+    remindDate = now
+  }
+
+  const remindAtIso = formatDateForStorage(remindDate)
+
+  return {dueAtIso, remindAtIso}
+}
+
+export function resolveTaskBadge(task: CalendarTask): {
+  variant: TaskBadgeVariant
+  due: Date | null
+  remind: Date | null
+} {
+  const due = parseDateSafe(task.dueAt || task.booking?.scheduledAt || null)
+  const remind = parseDateSafe(task.remindAt)
+  const now = new Date()
+
+  if (task.status === 'completed') {
+    return {variant: 'completed', due, remind}
+  }
+
+  if (due && isBefore(due, now)) {
+    return {variant: 'overdue', due, remind}
+  }
+
+  if (remind && !isBefore(remind, now) && remind.getTime() - now.getTime() <= 1000 * 60 * 60 * 24) {
+    return {variant: 'upcoming', due, remind}
+  }
+
+  if (due && due.getTime() - now.getTime() <= 1000 * 60 * 60 * 24) {
+    return {variant: 'upcoming', due, remind}
+  }
+
+  return {variant: 'scheduled', due, remind}
+}
+
+export function summarizeTaskBadges(tasksForDay: CalendarTask[]) {
+  let variant: TaskBadgeVariant | null = null
+
+  tasksForDay.forEach((task) => {
+    const {variant: currentVariant} = resolveTaskBadge(task)
+    if (currentVariant === 'overdue') {
+      variant = 'overdue'
+    } else if (currentVariant === 'upcoming' && variant !== 'overdue') {
+      variant = 'upcoming'
+    } else if (currentVariant === 'completed' && !variant) {
+      variant = 'completed'
+    } else if (!variant) {
+      variant = currentVariant
+    }
+  })
+
+  return variant
+}
+
+export function computeSnoozedReminder(
+  task: Pick<CalendarTask, 'dueAt' | 'remindAt' | 'booking' | 'status'>,
+  options?: {now?: Date; snoozeMinutes?: number},
+) {
+  const now = options?.now ?? new Date()
+  const snoozeMinutes = options?.snoozeMinutes ?? TASK_SNOOZE_MINUTES
+  const {due, remind} = resolveTaskBadge({
+    ...task,
+    _id: 'temp',
+    title: '',
+    status: task.status ?? 'pending',
+    notes: undefined,
+  } as CalendarTask)
+
+  const effectiveBase = remind && !isBefore(remind, now) ? remind : now
+  let nextReminder = addMinutes(effectiveBase, snoozeMinutes)
+
+  if (due && isBefore(due, nextReminder)) {
+    nextReminder = new Date(Math.max(due.getTime(), now.getTime()))
+  }
+
+  return nextReminder
+}
+
+export function deriveBookingStatusFromTaskAction(
+  action: 'complete' | 'snooze',
+  currentStatus?: string | null,
+) {
+  if (action === 'complete') {
+    return 'completed'
+  }
+
+  if (action === 'snooze') {
+    if (currentStatus && BOOKING_COMPLETED_STATUSES.has(currentStatus)) {
+      return currentStatus
+    }
+    return 'snoozed'
+  }
+
+  return currentStatus ?? 'confirmed'
+}
+
+export type TaskSyncPlan = {
+  shouldCreate: boolean
+  setPayload: Record<string, unknown>
+  unsetPayload: string[]
+  statusChange: 'complete' | 'reopen' | null
+  dueAtIso: string
+  remindAtIso: string
+  assignedRef?: {_type: 'reference'; _ref: string}
+}
+
+export function computeTaskSyncPlan(
+  booking: CalendarBooking,
+  existingTask?: CalendarTask | null,
+): TaskSyncPlan {
+  const scheduledDate = parseDateSafe(booking.scheduledAt)
+  const {dueAtIso, remindAtIso} = computeTaskTiming(booking, scheduledDate)
+  const assignedRef = booking.customer?._id
+    ? ({
+        _type: 'reference' as const,
+        _ref: booking.customer._id,
+      } as const)
+    : undefined
+
+  if (!existingTask) {
+    return {
+      shouldCreate: true,
+      setPayload: {
+        dueAt: dueAtIso,
+        remindAt: remindAtIso,
+        notes: booking.notes || undefined,
+        status: 'pending',
+      },
+      unsetPayload: [],
+      statusChange: null,
+      dueAtIso,
+      remindAtIso,
+      assignedRef,
+    }
+  }
+
+  const setPayload: Record<string, unknown> = {}
+  const unsetPayload: string[] = []
+
+  if (!isoTimesEqual(existingTask.dueAt ?? null, dueAtIso)) {
+    setPayload.dueAt = dueAtIso
+  }
+
+  if (!isoTimesEqual(existingTask.remindAt ?? null, remindAtIso)) {
+    setPayload.remindAt = remindAtIso
+  }
+
+  if (assignedRef) {
+    if (existingTask.assignedTo?._id !== assignedRef._ref) {
+      setPayload.assignedTo = assignedRef
+    }
+  } else if (existingTask.assignedTo?._id) {
+    unsetPayload.push('assignedTo')
+  }
+
+  if (booking.notes && booking.notes !== existingTask.notes) {
+    setPayload.notes = booking.notes
+  } else if (!booking.notes && existingTask.notes) {
+    unsetPayload.push('notes')
+  }
+
+  const shouldComplete = booking.status ? BOOKING_COMPLETED_STATUSES.has(booking.status) : false
+  let statusChange: 'complete' | 'reopen' | null = null
+
+  if (shouldComplete && existingTask.status !== 'completed') {
+    setPayload.status = 'completed'
+    statusChange = 'complete'
+  } else if (!shouldComplete && existingTask.status === 'completed') {
+    setPayload.status = 'pending'
+    statusChange = 'reopen'
+  }
+
+  return {
+    shouldCreate: false,
+    setPayload,
+    unsetPayload,
+    statusChange,
+    dueAtIso,
+    remindAtIso,
+    assignedRef,
+  }
+}
+
+export async function withRetry<T>(
+  operation: () => Promise<T>,
+  options: {attempts?: number; delayMs?: number} = {},
+): Promise<T> {
+  const attempts = options.attempts ?? 3
+  const delayMs = options.delayMs ?? 500
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await operation()
+    } catch (err) {
+      lastError = err
+      if (attempt < attempts) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs * attempt))
+      }
+    }
+  }
+
+  throw lastError
+}

--- a/packages/sanity-config/src/components/studio/CalendarTasksWidget.tsx
+++ b/packages/sanity-config/src/components/studio/CalendarTasksWidget.tsx
@@ -1,0 +1,465 @@
+import React, {useCallback, useEffect, useMemo, useState} from 'react'
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  Flex,
+  Heading,
+  Inline,
+  Spinner,
+  Stack,
+  Text,
+  Tooltip,
+  useToast,
+} from '@sanity/ui'
+import {BellIcon} from '@sanity/icons'
+import {format, formatDistanceToNow} from 'date-fns'
+import {useClient} from 'sanity'
+import {useRouter} from 'sanity/router'
+
+import {
+  BookingCustomer,
+  CalendarBooking,
+  CalendarTask,
+  TASK_BADGE_DESCRIPTIONS,
+  TASK_BADGE_STYLES,
+  computeSnoozedReminder,
+  deriveBookingStatusFromTaskAction,
+  formatDateForStorage,
+  resolveTaskBadge,
+  withRetry,
+} from '../../apps/calendar/shared'
+
+const CUSTOMER_PROJECTION = `{
+  _id,
+  firstName,
+  lastName,
+  name,
+  email,
+  phone
+}`
+
+const TASK_WIDGET_QUERY = `*[_type == "calendarTask"] | order(remindAt asc nulls last, dueAt asc nulls last) {
+  _id,
+  title,
+  status,
+  dueAt,
+  remindAt,
+  booking->{
+    _id,
+    scheduledAt,
+    status,
+    "documentId": select(startsWith(_id, "drafts.") => replace(_id, "drafts.", ""), _id),
+    "draftId": select(startsWith(_id, "drafts.") => _id, null),
+    "publishedId": select(startsWith(_id, "drafts.") => null, _id),
+    customer->${CUSTOMER_PROJECTION}
+  },
+  assignedTo->${CUSTOMER_PROJECTION}
+}`
+
+const TASK_WIDGET_LISTEN_QUERY = '*[_type == "calendarTask"]'
+
+type BookingResult = {
+  _id: string
+  documentId: string
+  draftId?: string | null
+  publishedId?: string | null
+  scheduledAt?: string | null
+  status?: string | null
+  customer?: BookingCustomer | null
+}
+
+type TaskResult = {
+  _id: string
+  title?: string | null
+  status?: string | null
+  dueAt?: string | null
+  remindAt?: string | null
+  booking?: BookingResult | null
+  assignedTo?: BookingCustomer | null
+}
+
+function getDisplayName(customer?: BookingCustomer | null) {
+  if (!customer) return 'Unassigned'
+  const first = customer.firstName?.trim()
+  const last = customer.lastName?.trim()
+  if (first || last) return [first, last].filter(Boolean).join(' ')
+  if (customer.name?.trim()) return customer.name.trim()
+  if (customer.email?.trim()) return customer.email.trim()
+  if (customer.phone?.trim()) return customer.phone.trim()
+  return 'Unassigned'
+}
+
+function normalizeBooking(record?: BookingResult | null): CalendarBooking | null {
+  if (!record) return null
+  return {
+    documentId: record.documentId,
+    draftId: record.draftId ?? undefined,
+    publishedId: record.publishedId ?? undefined,
+    bookingId: null,
+    service: null,
+    scheduledAt: record.scheduledAt ?? null,
+    status: record.status ?? null,
+    notes: null,
+    createdAt: null,
+    updatedAt: null,
+    customer: record.customer ?? null,
+  }
+}
+
+function normalizeTask(record: TaskResult): CalendarTask {
+  return {
+    _id: record._id,
+    title: record.title?.trim() || 'Calendar task',
+    status: record.status || 'pending',
+    dueAt: record.dueAt ?? null,
+    remindAt: record.remindAt ?? null,
+    notes: null,
+    booking: normalizeBooking(record.booking),
+    assignedTo: record.assignedTo ?? null,
+  }
+}
+
+const CalendarTasksWidget: React.FC = () => {
+  const client = useClient({apiVersion: '2024-10-01'})
+  const router = useRouter()
+  const {push: pushToast} = useToast()
+  const [tasks, setTasks] = useState<CalendarTask[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+  const [pendingTaskIds, setPendingTaskIds] = useState<string[]>([])
+
+  const addPendingTask = useCallback((id: string) => {
+    setPendingTaskIds((prev) => (prev.includes(id) ? prev : [...prev, id]))
+  }, [])
+
+  const removePendingTask = useCallback((id: string) => {
+    setPendingTaskIds((prev) => prev.filter((item) => item !== id))
+  }, [])
+
+  const loadTasks = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const records = await client.fetch<TaskResult[]>(TASK_WIDGET_QUERY, {}, {perspective: 'previewDrafts'})
+      setTasks(records.map(normalizeTask))
+    } catch (err) {
+      console.error('Failed to load calendar tasks', err)
+      setError(err instanceof Error ? err.message : 'Unable to load tasks')
+    } finally {
+      setLoading(false)
+    }
+  }, [client])
+
+  useEffect(() => {
+    loadTasks()
+  }, [loadTasks])
+
+  useEffect(() => {
+    const subscription = client
+      .listen(TASK_WIDGET_LISTEN_QUERY, {}, {visibility: 'query', tag: 'calendar-tasks-widget'})
+      .subscribe(() => {
+        loadTasks()
+      })
+
+    return () => subscription.unsubscribe()
+  }, [client, loadTasks])
+
+  const actionableTasks = useMemo(() => {
+    return tasks
+      .filter((task) => task.status !== 'completed')
+      .map((task) => {
+        const result = resolveTaskBadge(task)
+        const sortValue =
+          result.remind?.getTime() ?? result.due?.getTime() ?? Number.MAX_SAFE_INTEGER
+        return {...result, sortValue, task}
+      })
+      .sort((a, b) => a.sortValue - b.sortValue)
+  }, [tasks])
+
+  const handleOpenTask = useCallback(
+    (task: CalendarTask) => {
+      router.navigateIntent('edit', {id: task._id, type: 'calendarTask'})
+    },
+    [router],
+  )
+
+  const syncBookingStatus = useCallback(
+    async (action: 'complete' | 'snooze', task: CalendarTask) => {
+      if (!task.booking) return
+
+      const nextStatus = deriveBookingStatusFromTaskAction(action, task.booking.status)
+      if (!nextStatus || task.booking.status === nextStatus) {
+        return
+      }
+
+      try {
+        await withRetry(() => {
+          const transaction = client.transaction()
+          let hasMutations = false
+
+          const patchBooking = (id?: string | null) => {
+            if (!id) return
+            transaction.patch(id, {set: {status: nextStatus}})
+            hasMutations = true
+          }
+
+          patchBooking(task.booking?.documentId)
+          patchBooking(task.booking?.draftId)
+
+          if (!hasMutations) {
+            return Promise.resolve(undefined)
+          }
+
+          return transaction.commit({tag: 'calendar-widget-booking-sync'})
+        })
+
+        setTasks((prev) =>
+          prev.map((item) =>
+            item._id === task._id
+              ? {
+                  ...item,
+                  booking: item.booking
+                    ? {
+                        ...item.booking,
+                        status: nextStatus,
+                      }
+                    : item.booking,
+                }
+              : item,
+          ),
+        )
+      } catch (err) {
+        console.error('Failed to sync booking status for widget task', err)
+        pushToast({
+          status: 'warning',
+          title: 'Booking status update failed',
+          description:
+            err instanceof Error
+              ? err.message
+              : 'Unable to reflect the reminder update on the booking.',
+        })
+      }
+    },
+    [client, pushToast],
+  )
+
+  const handleCompleteTask = useCallback(
+    async (task: CalendarTask) => {
+      addPendingTask(task._id)
+      try {
+        await withRetry(() =>
+          client
+            .patch(task._id, {set: {status: 'completed'}})
+            .commit({tag: 'calendar-widget-complete'}),
+        )
+
+        const updatedTask: CalendarTask = {...task, status: 'completed'}
+
+        setTasks((prev) =>
+          prev.map((item) => (item._id === task._id ? updatedTask : item)),
+        )
+
+        await syncBookingStatus('complete', updatedTask)
+
+        pushToast({
+          status: 'success',
+          title: 'Task completed',
+          description: `Marked "${task.title}" as done.`,
+        })
+      } catch (err) {
+        console.error('Failed to complete calendar task', err)
+        pushToast({
+          status: 'error',
+          title: 'Unable to complete task',
+          description: err instanceof Error ? err.message : 'An unexpected error occurred.',
+        })
+      } finally {
+        removePendingTask(task._id)
+      }
+    },
+    [addPendingTask, client, pushToast, removePendingTask, syncBookingStatus],
+  )
+
+  const handleSnoozeTask = useCallback(
+    async (task: CalendarTask) => {
+      addPendingTask(task._id)
+      const nextReminder = computeSnoozedReminder(task)
+      const nextReminderIso = formatDateForStorage(nextReminder)
+
+      try {
+        await withRetry(() =>
+          client
+            .patch(task._id, {set: {remindAt: nextReminderIso}})
+            .commit({tag: 'calendar-widget-snooze'}),
+        )
+
+        setTasks((prev) =>
+          prev.map((item) =>
+            item._id === task._id ? {...item, remindAt: nextReminderIso} : item,
+          ),
+        )
+
+        await syncBookingStatus('snooze', task)
+
+        pushToast({
+          status: 'success',
+          title: 'Reminder snoozed',
+          description: `We will remind you ${format(nextReminder, "MMM d, h:mm a")}.`,
+        })
+      } catch (err) {
+        console.error('Failed to snooze calendar task', err)
+        pushToast({
+          status: 'error',
+          title: 'Unable to snooze reminder',
+          description: err instanceof Error ? err.message : 'An unexpected error occurred.',
+        })
+      } finally {
+        removePendingTask(task._id)
+      }
+    },
+    [addPendingTask, client, pushToast, removePendingTask, syncBookingStatus],
+  )
+
+  const handleOpenCalendar = useCallback(() => {
+    router.navigateUrl('/desk/calendar-app')
+  }, [router])
+
+  const hasPending = pendingTaskIds.length > 0
+
+  return (
+    <Card padding={4} radius={3} shadow={1} tone="transparent">
+      <Stack space={3}>
+        <Flex align={['flex-start', 'center']} justify="space-between" gap={3} wrap="wrap">
+          <Flex align="center" gap={3}>
+            <BellIcon />
+            <Heading size={1}>Calendar reminders</Heading>
+          </Flex>
+          {hasPending && (
+            <Inline space={2} style={{alignItems: 'center', display: 'flex'}}>
+              <Spinner size={1} />
+              <Text size={0} muted>Saving reminder updates…</Text>
+            </Inline>
+          )}
+        </Flex>
+
+        {loading && (
+          <Flex align="center" gap={3}>
+            <Spinner />
+            <Text size={1}>Loading reminders…</Text>
+          </Flex>
+        )}
+
+        {error && (
+          <Text size={1} tone="critical">
+            {error}
+          </Text>
+        )}
+
+        {!loading && !error && actionableTasks.length === 0 && (
+          <Text size={1} muted>
+            No pending reminders. Great job staying on top of things!
+          </Text>
+        )}
+
+        {!loading && !error && actionableTasks.length > 0 && (
+          <Stack space={3}>
+            {actionableTasks.slice(0, 6).map(({task, due, remind, variant}) => {
+              const badgeStyles = TASK_BADGE_STYLES[variant]
+              const isSaving = pendingTaskIds.includes(task._id)
+              return (
+                <Card
+                  key={task._id}
+                  padding={3}
+                  radius={2}
+                  shadow={1}
+                  tone="transparent"
+                  style={{background: 'rgba(15,23,42,0.85)'}}
+                >
+                  <Stack space={2}>
+                    <Flex align="center" justify="space-between">
+                      <Text size={1} weight="semibold">
+                        {task.title || 'Calendar task'}
+                      </Text>
+                      <Tooltip
+                        portal
+                        content={
+                          <Box padding={2} style={{maxWidth: 220}}>
+                            <Text size={1}>{TASK_BADGE_DESCRIPTIONS[variant]}</Text>
+                          </Box>
+                        }
+                      >
+                        <Badge
+                          tone={badgeStyles.tone}
+                          style={{
+                            borderColor: badgeStyles.borderColor,
+                            background: badgeStyles.background,
+                            color: badgeStyles.textColor,
+                            textTransform: 'capitalize',
+                          }}
+                        >
+                          {badgeStyles.label}
+                        </Badge>
+                      </Tooltip>
+                    </Flex>
+                    <Text size={0} muted>
+                      Assigned to {getDisplayName(task.assignedTo)}
+                    </Text>
+                    {due && (
+                      <Text size={0} muted>
+                        Due {format(due, 'MMM d, h:mm a')} · {formatDistanceToNow(due, {addSuffix: true})}
+                      </Text>
+                    )}
+                    {remind && (
+                      <Text size={0} muted>
+                        Reminder {formatDistanceToNow(remind, {addSuffix: true})}
+                      </Text>
+                    )}
+                    {task.booking && (
+                      <Text size={0} muted>
+                        Booking: {getDisplayName(task.booking.customer)}
+                      </Text>
+                    )}
+                    <Inline space={2}>
+                      <Button
+                        text="Open"
+                        tone="primary"
+                        mode="ghost"
+                        onClick={() => handleOpenTask(task)}
+                        disabled={isSaving}
+                      />
+                      <Button
+                        text="Complete"
+                        mode="ghost"
+                        onClick={() => handleCompleteTask(task)}
+                        disabled={isSaving}
+                        loading={isSaving}
+                      />
+                      <Button
+                        text="Snooze"
+                        mode="ghost"
+                        tone="default"
+                        onClick={() => handleSnoozeTask(task)}
+                        disabled={isSaving}
+                        loading={isSaving}
+                      />
+                      <Button
+                        text="Open calendar"
+                        mode="ghost"
+                        onClick={handleOpenCalendar}
+                        disabled={isSaving}
+                      />
+                    </Inline>
+                  </Stack>
+                </Card>
+              )
+            })}
+          </Stack>
+        )}
+      </Stack>
+    </Card>
+  )
+}
+
+export default CalendarTasksWidget

--- a/packages/sanity-config/src/components/studio/HomePane.tsx
+++ b/packages/sanity-config/src/components/studio/HomePane.tsx
@@ -6,11 +6,13 @@ import {
   OrdersDocumentTable,
   ProductsDocumentTable,
 } from './documentTables'
+import CalendarTasksWidget from './CalendarTasksWidget'
 
 const HomePane = React.forwardRef<HTMLDivElement, Record<string, never>>((_props, ref) => {
   return (
     <Box padding={4} ref={ref}>
       <Stack space={4}>
+        <CalendarTasksWidget />
         <OrdersDocumentTable title="New orders" filter={NEW_ORDERS_FILTER} emptyState="No new orders" />
         <ProductsDocumentTable />
         <CustomersDocumentTable />

--- a/packages/sanity-config/src/schemaTypes/documents/booking.ts
+++ b/packages/sanity-config/src/schemaTypes/documents/booking.ts
@@ -9,7 +9,12 @@ export default defineType({
     defineField({ name: 'customer', title: 'Customer', type: 'reference', to: [{ type: 'customer' }] }),
     defineField({ name: 'service', title: 'Service', type: 'string' }),
     defineField({ name: 'scheduledAt', title: 'Scheduled At', type: 'datetime' }),
-    defineField({ name: 'status', title: 'Status', type: 'string', options: { list: ['confirmed', 'cancelled', 'rescheduled', 'no-show'] } }),
+    defineField({
+      name: 'status',
+      title: 'Status',
+      type: 'string',
+      options: {list: ['confirmed', 'cancelled', 'rescheduled', 'no-show', 'snoozed', 'completed']},
+    }),
     defineField({ name: 'notes', title: 'Notes', type: 'text' }),
     defineField({ name: 'createdAt', title: 'Created At', type: 'datetime', initialValue: () => new Date().toISOString() }),
   ]

--- a/packages/sanity-config/src/schemaTypes/documents/calendarTask.ts
+++ b/packages/sanity-config/src/schemaTypes/documents/calendarTask.ts
@@ -1,0 +1,61 @@
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
+  name: 'calendarTask',
+  title: 'Calendar Task',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required().max(120),
+    }),
+    defineField({
+      name: 'status',
+      title: 'Status',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'Pending', value: 'pending'},
+          {title: 'In progress', value: 'in-progress'},
+          {title: 'Completed', value: 'completed'},
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'pending',
+    }),
+    defineField({
+      name: 'booking',
+      title: 'Booking',
+      type: 'reference',
+      to: [{type: 'booking'}],
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'assignedTo',
+      title: 'Assigned to',
+      type: 'reference',
+      to: [{type: 'customer'}],
+    }),
+    defineField({name: 'dueAt', title: 'Due at', type: 'datetime'}),
+    defineField({name: 'remindAt', title: 'Remind at', type: 'datetime'}),
+    defineField({name: 'notes', title: 'Notes', type: 'text'}),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      status: 'status',
+      bookingId: 'booking._ref',
+      dueAt: 'dueAt',
+    },
+    prepare({title, status, bookingId, dueAt}) {
+      return {
+        title: title || 'Calendar task',
+        subtitle: [status, bookingId, dueAt ? new Date(dueAt).toLocaleString() : null]
+          .filter(Boolean)
+          .join(' · '),
+      }
+    },
+  },
+})

--- a/packages/sanity-config/src/schemaTypes/index.ts
+++ b/packages/sanity-config/src/schemaTypes/index.ts
@@ -221,6 +221,7 @@ import {bankAccountType} from './documents/bankAccount'
 import {checkType} from './documents/check'
 import expense from './documents/expense'
 import booking from './documents/booking'
+import calendarTask from './documents/calendarTask'
 import stripeWebhookEvent from './documents/stripeWebhookEvent'
 
 const documents = [
@@ -251,6 +252,7 @@ const documents = [
   wheelQuote,
   expense,
   booking,
+  calendarTask,
   stripeWebhookEvent,
   campaign,
   attribution,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
       typescript:
         specifier: ^5.1.6
         version: 5.9.2
+      vitest:
+        specifier: ^2.1.4
+        version: 2.1.9(@types/node@22.18.12)(jsdom@23.2.0(canvas@3.2.0))
 
   packages/sanity-config:
     dependencies:
@@ -1161,6 +1164,12 @@ packages:
     resolution: {integrity: sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==}
     engines: {node: '>=18.0.0'}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.10':
     resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
     engines: {node: '>=18'}
@@ -1185,6 +1194,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.10':
     resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
     engines: {node: '>=18'}
@@ -1207,6 +1222,12 @@ packages:
     resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.10':
@@ -1233,6 +1254,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.10':
     resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
     engines: {node: '>=18'}
@@ -1257,6 +1284,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.10':
     resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
     engines: {node: '>=18'}
@@ -1279,6 +1312,12 @@ packages:
     resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.10':
@@ -1305,6 +1344,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.10':
     resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
     engines: {node: '>=18'}
@@ -1327,6 +1372,12 @@ packages:
     resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.10':
@@ -1353,6 +1404,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.10':
     resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
     engines: {node: '>=18'}
@@ -1375,6 +1432,12 @@ packages:
     resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.10':
@@ -1401,6 +1464,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.10':
     resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
     engines: {node: '>=18'}
@@ -1423,6 +1492,12 @@ packages:
     resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.10':
@@ -1449,6 +1524,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.10':
     resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
     engines: {node: '>=18'}
@@ -1471,6 +1552,12 @@ packages:
     resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.10':
@@ -1497,6 +1584,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.10':
     resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
     engines: {node: '>=18'}
@@ -1521,6 +1614,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.10':
     resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
     engines: {node: '>=18'}
@@ -1543,6 +1642,12 @@ packages:
     resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.10':
@@ -1593,6 +1698,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.10':
     resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
     engines: {node: '>=18'}
@@ -1641,6 +1752,12 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.25.10':
     resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
     engines: {node: '>=18'}
@@ -1683,6 +1800,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.10':
     resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
     engines: {node: '>=18'}
@@ -1706,6 +1829,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.10':
     resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
@@ -1731,6 +1860,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.10':
     resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
     engines: {node: '>=18'}
@@ -1753,6 +1888,12 @@ packages:
     resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.10':
@@ -3747,6 +3888,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   '@vue/compiler-core@3.5.21':
     resolution: {integrity: sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==}
 
@@ -4040,6 +4210,10 @@ packages:
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-module-types@6.0.1:
     resolution: {integrity: sha512-WHw67kLXYbZuHTmcdbIrVArCq5wxo6NEuj3hiYAWr8mwJeC+C2mMCIBIWCiDoCye/OF/xelc+teJ1ERoWmnEIA==}
     engines: {node: '>=18'}
@@ -4273,6 +4447,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cacheable-lookup@7.0.0:
     resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
     engines: {node: '>=14.16'}
@@ -4345,6 +4523,10 @@ packages:
     peerDependencies:
       react: '>=17.0.0'
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -4380,6 +4562,10 @@ packages:
 
   chardet@2.1.0:
     resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -4844,6 +5030,10 @@ packages:
     resolution: {integrity: sha512-e7oWH1LzIdv/prMQ7pmlDlaVoL64glqzvNgkgQNgyec9ORPHrT2jaOqMtRyqJuwWjtfb6v+2rk9pmaHj+F137A==}
     engines: {node: '>= 16'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -5189,6 +5379,11 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
 
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.25.10:
     resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
     engines: {node: '>=18'}
@@ -5408,6 +5603,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
 
   express-logging@1.1.1:
     resolution: {integrity: sha512-1KboYwxxCG5kwkJHR5LjFDTD1Mgl8n4PIMcCuhhd/1OqaxlC68P3QKbvvAbZVUtVgtlxEdTgSUwf6yxwzRCuuA==}
@@ -6916,6 +7115,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -7852,6 +8054,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pdf-lib@1.17.1:
     resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
@@ -8840,6 +9046,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -8975,6 +9184,9 @@ packages:
 
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   stackblur-canvas@2.7.0:
     resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
@@ -9245,12 +9457,27 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
@@ -9804,12 +10031,48 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-tsconfig-paths@5.1.4:
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
     peerDependencies:
       vite: '*'
     peerDependenciesMeta:
       vite:
+        optional: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
         optional: true
 
   vite@6.3.6:
@@ -9900,6 +10163,31 @@ packages:
       vite:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -9983,6 +10271,11 @@ packages:
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@3.1.0:
@@ -11413,6 +11706,9 @@ snapshots:
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.10':
     optional: true
 
@@ -11423,6 +11719,9 @@ snapshots:
     optional: true
 
   '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.10':
@@ -11437,6 +11736,9 @@ snapshots:
   '@esbuild/android-arm64@0.25.9':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.10':
     optional: true
 
@@ -11447,6 +11749,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm@0.25.9':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.10':
@@ -11461,6 +11766,9 @@ snapshots:
   '@esbuild/android-x64@0.25.9':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.10':
     optional: true
 
@@ -11471,6 +11779,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.10':
@@ -11485,6 +11796,9 @@ snapshots:
   '@esbuild/darwin-x64@0.25.9':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.10':
     optional: true
 
@@ -11495,6 +11809,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.10':
@@ -11509,6 +11826,9 @@ snapshots:
   '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.10':
     optional: true
 
@@ -11519,6 +11839,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.10':
@@ -11533,6 +11856,9 @@ snapshots:
   '@esbuild/linux-arm@0.25.9':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.10':
     optional: true
 
@@ -11543,6 +11869,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.10':
@@ -11557,6 +11886,9 @@ snapshots:
   '@esbuild/linux-loong64@0.25.9':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.10':
     optional: true
 
@@ -11567,6 +11899,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.10':
@@ -11581,6 +11916,9 @@ snapshots:
   '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.10':
     optional: true
 
@@ -11593,6 +11931,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.9':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.10':
     optional: true
 
@@ -11603,6 +11944,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.25.9':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.10':
@@ -11629,6 +11973,9 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.9':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.10':
     optional: true
 
@@ -11653,6 +12000,9 @@ snapshots:
   '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/openbsd-x64@0.25.10':
     optional: true
 
@@ -11674,6 +12024,9 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.9':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.10':
     optional: true
 
@@ -11684,6 +12037,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.10':
@@ -11698,6 +12054,9 @@ snapshots:
   '@esbuild/win32-arm64@0.25.9':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.10':
     optional: true
 
@@ -11708,6 +12067,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.10':
@@ -14571,6 +14933,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.18.12))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.18.12)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.19
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@vue/compiler-core@3.5.21':
     dependencies:
       '@babel/parser': 7.28.4
@@ -14939,6 +15341,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  assertion-error@2.0.1: {}
+
   ast-module-types@6.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -15282,6 +15686,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   cacheable-lookup@7.0.0: {}
 
   cacheable-request@10.2.14:
@@ -15363,6 +15769,14 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -15391,6 +15805,8 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   chardet@2.1.0: {}
+
+  check-error@2.1.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -15849,6 +16265,8 @@ snapshots:
 
   deeks@3.1.0: {}
 
+  deep-eql@5.0.2: {}
+
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -16227,6 +16645,32 @@ snapshots:
       esbuild: 0.25.11
     transitivePeerDependencies:
       - supports-color
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.10:
     optionalDependencies:
@@ -16607,6 +17051,8 @@ snapshots:
   exif-component@1.0.1: {}
 
   expand-template@2.0.3: {}
+
+  expect-type@1.2.2: {}
 
   express-logging@1.1.1:
     dependencies:
@@ -18353,6 +18799,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lowercase-keys@3.0.0: {}
 
   lru-cache@10.4.3: {}
@@ -19575,6 +20023,8 @@ snapshots:
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pdf-lib@1.17.1:
     dependencies:
@@ -21178,6 +21628,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -21314,6 +21766,8 @@ snapshots:
       stackframe: 1.3.4
 
   stack-trace@0.0.10: {}
+
+  stackback@0.0.2: {}
 
   stackblur-canvas@2.7.0:
     optional: true
@@ -21660,12 +22114,20 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   tldts-core@6.1.86: {}
 
@@ -22167,6 +22629,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@2.1.9(@types/node@22.18.12):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@10.2.2)
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.18.12)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@7.1.7(@types/node@22.18.12)(jiti@2.5.1)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -22177,6 +22657,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  vite@5.4.21(@types/node@22.18.12):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.50.1
+    optionalDependencies:
+      '@types/node': 22.18.12
+      fsevents: 2.3.3
 
   vite@6.3.6(@types/node@22.18.12)(jiti@2.5.1)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
@@ -22211,6 +22700,42 @@ snapshots:
   vitefu@1.1.1(vite@6.3.6(@types/node@22.18.12)(jiti@2.5.1)(tsx@4.20.6)(yaml@2.8.1)):
     optionalDependencies:
       vite: 6.3.6(@types/node@22.18.12)(jiti@2.5.1)(tsx@4.20.6)(yaml@2.8.1)
+
+  vitest@2.1.9(@types/node@22.18.12)(jsdom@23.2.0(canvas@3.2.0)):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.18.12))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@10.2.2)
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.18.12)
+      vite-node: 2.1.9(@types/node@22.18.12)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.18.12
+      jsdom: 23.2.0(canvas@3.2.0)
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   void-elements@3.1.0: {}
 
@@ -22312,6 +22837,11 @@ snapshots:
   which@5.0.0:
     dependencies:
       isexe: 3.1.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@3.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- extract shared calendar utilities to normalize booking/task data, store local timestamps, and share retry logic across the studio
- sync booking/task state bidirectionally with tooltips, loading cues, and reminder snooze handling in both the calendar view and dashboard widget
- add vitest-powered smoke tests for booking/task sync, snooze reminders, and quick actions alongside a package script for running them

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_69085ee6d1e8832c950aa7d268432343