### PR TITLE
chore: tidy cart metadata after carrier cleanup

### DIFF
--- a/packages/sanity-config/src/utils/cartItemDetails.ts
+++ b/packages/sanity-config/src/utils/cartItemDetails.ts
@@ -23,22 +23,6 @@ const OPTION_KEYWORDS = [
   'color',
 ]
 const UPGRADE_KEYWORDS = ['upgrade', 'addon', 'add_on', 'add-on', 'addon', 'addOn', 'accessory']
-const CUSTOMIZATION_KEYWORDS = [
-  'custom',
-  'customization',
-  'personalization',
-  'personalise',
-  'personalize',
-  'engraving',
-  'engrave',
-  'monogram',
-  'message',
-  'inscription',
-  'note',
-  'text',
-  'initial',
-  'initials',
-]
 const IGNORE_OPTION_KEYS = [
   'shipping_option',
   'shipping_options',


### PR DESCRIPTION
## Summary
- audit the shipping utilities to confirm only EasyPost/Stripe integrations remain active
- drop the unused `CUSTOMIZATION_KEYWORDS` constant from the cart item detail helper so linting stays green

## Testing
- pnpm build
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915a0c1b904832cb1e0d972d27c3ed5)