### PR TITLE
Honor product customization requirements during cart enrichment

### DIFF
--- a/netlify/lib/__tests__/cartEnrichment.test.ts
+++ b/netlify/lib/__tests__/cartEnrichment.test.ts
@@ -58,6 +58,7 @@ describe('enrichCartItemsFromSanity', () => {
           ...(JSON.parse(JSON.stringify(baseCartItem)) as CartItem),
           optionSummary: 'Size: Large',
           optionDetails: ['Size: Large'],
+          customizations: ['Engraving: Custom Text'],
         },
       ],
       client,

--- a/netlify/lib/cartEnrichment.ts
+++ b/netlify/lib/cartEnrichment.ts
@@ -473,9 +473,7 @@ export async function enrichCartItemsFromSanity(
         ? item.customizations
         : undefined
 
-    const shouldCheckCustomizations =
-      Boolean(product.customizationRequirements?.length) &&
-      (Boolean(customSelections?.length) || (!optionSummary && !(optionDetails && optionDetails.length)))
+    const shouldCheckCustomizations = Boolean(product.customizationRequirements?.length)
 
     const issues = validateCartSelections(
       {


### PR DESCRIPTION
## Summary
- include product customization requirements when fetching cart product summaries
- ensure cart enrichment validates customizations against available selections without double-flagging satisfied carts
- surface customization data on cart items for selection validation handling

## Testing
- `pnpm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69164dfb85e8832c9d893f41f4ee3ac6)