### PR TITLE
Centralize Resend API key resolution

### DIFF
--- a/netlify/functions/email-subscribe.ts
+++ b/netlify/functions/email-subscribe.ts
@@ -3,6 +3,7 @@ import {createClient} from '@sanity/client'
 import {Resend} from 'resend'
 import {syncContact} from '../lib/resend/contacts'
 import {computeCustomerName, splitFullName} from '../../shared/customerName'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 
 const sanityClient = createClient({
   projectId: process.env.SANITY_PROJECT_ID || 'r4og35qd',
@@ -12,7 +13,7 @@ const sanityClient = createClient({
   useCdn: false,
 })
 
-const resend = new Resend(process.env.RESEND_API_KEY!)
+const resend = new Resend(resolveResendApiKey()!)
 
 export const handler: Handler = async (event) => {
   const headers = {

--- a/netlify/functions/fulfillOrder.ts
+++ b/netlify/functions/fulfillOrder.ts
@@ -2,6 +2,7 @@ import type {Handler} from '@netlify/functions'
 import {randomUUID} from 'crypto'
 import {Resend} from 'resend'
 import {buildTrackingEmailHtml} from '../../shared/email/trackingEmail'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 import {sanityClient} from '../lib/sanityClient'
 import {getEasyPostClient, resolveDimensions, resolveWeight} from '../lib/easypostClient'
 import {getEasyPostFromAddress} from '../lib/ship-from'
@@ -51,7 +52,7 @@ const buildCorsHeaders = (origin?: string) => ({
   'Access-Control-Allow-Methods': 'OPTIONS,POST',
 })
 
-const resendApiKey = process.env.RESEND_API_KEY || ''
+const resendApiKey = resolveResendApiKey() || ''
 const resendFrom =
   process.env.RESEND_FROM || 'F.A.S. Motorsports <noreply@updates.fasmotorsports.com>'
 const resendClient = resendApiKey ? new Resend(resendApiKey) : null

--- a/netlify/functions/inventoryReorderCheck.ts
+++ b/netlify/functions/inventoryReorderCheck.ts
@@ -1,6 +1,7 @@
 import {schedule} from '@netlify/functions'
 import {createClient} from '@sanity/client'
 import {Resend} from 'resend'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 import {generateReferenceCode} from '../../shared/referenceCodes'
 import {applyInventoryChanges} from '../../shared/inventory'
 import {INVENTORY_DOCUMENT_TYPE} from '../../shared/docTypes'
@@ -13,7 +14,8 @@ const sanity = createClient({
   useCdn: false,
 })
 
-const resendClient = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null
+const resendApiKey = resolveResendApiKey()
+const resendClient = resendApiKey ? new Resend(resendApiKey) : null
 const alertRecipient =
   process.env.INVENTORY_ALERT_EMAIL ||
   process.env.ORDERS_ALERT_EMAIL ||

--- a/netlify/functions/manual-fulfill-order.ts
+++ b/netlify/functions/manual-fulfill-order.ts
@@ -12,6 +12,7 @@ import {
 import {canonicalizeTrackingNumber, validateTrackingNumber} from '../../shared/tracking'
 import {consumeInventoryForItems} from '../../shared/inventory'
 import {logFunctionExecution} from '../../utils/functionLogger'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 
 const configuredOrigins = [
   process.env.CORS_ALLOW,
@@ -55,7 +56,8 @@ const sanity = createClient({
   useCdn: false,
 })
 
-const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null
+const resendApiKey = resolveResendApiKey()
+const resend = resendApiKey ? new Resend(resendApiKey) : null
 const resendFrom = process.env.RESEND_FROM || 'FAS Motorsports <noreply@updates.fasmotorsports.com>'
 
 const netlifyContext = (process.env.CONTEXT || '').toLowerCase()

--- a/netlify/functions/refundOrder.ts
+++ b/netlify/functions/refundOrder.ts
@@ -3,6 +3,7 @@ import Stripe from 'stripe'
 import {Resend} from 'resend'
 import {sanityClient} from '../lib/sanityClient'
 import {easypostRequest} from '../lib/easypostClient'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 
 type OrderDoc = {
   _id: string
@@ -22,7 +23,7 @@ const stripe = stripeSecretKey
     })
   : null
 
-const resendApiKey = process.env.RESEND_API_KEY || ''
+const resendApiKey = resolveResendApiKey() || ''
 const resendFrom =
   process.env.RESEND_FROM || 'F.A.S. Motorsports <noreply@updates.fasmotorsports.com>'
 const resendClient = resendApiKey ? new Resend(resendApiKey) : null

--- a/netlify/functions/requestFreightQuote.ts
+++ b/netlify/functions/requestFreightQuote.ts
@@ -2,6 +2,7 @@
 import type {Handler} from '@netlify/functions'
 import {createClient} from '@sanity/client'
 import {Resend} from 'resend'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 import {randomUUID} from 'crypto'
 
 const DEFAULT_ORIGINS = (
@@ -28,7 +29,8 @@ const sanity = createClient({
   token: process.env.SANITY_API_TOKEN,
   useCdn: false,
 })
-const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null
+const resendApiKey = resolveResendApiKey()
+const resend = resendApiKey ? new Resend(resendApiKey) : null
 
 function parseDims(
   s?: string,

--- a/netlify/functions/resendInvoiceEmail.ts
+++ b/netlify/functions/resendInvoiceEmail.ts
@@ -5,6 +5,7 @@ import imageUrlBuilder from '@sanity/image-url'
 import Stripe from 'stripe'
 import {renderInvoicePdf, computeInvoiceTotals} from '../lib/invoicePdf'
 import {fetchPrintSettings} from '../lib/printSettings'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 
 // --- CORS (more permissive localhost-aware)
 const DEFAULT_ORIGINS = (
@@ -28,7 +29,7 @@ function makeCORS(origin?: string) {
   }
 }
 
-const resend = new Resend(process.env.RESEND_API_KEY)
+const resend = new Resend(resolveResendApiKey()!)
 const stripe = process.env.STRIPE_SECRET_KEY
   ? new Stripe(process.env.STRIPE_SECRET_KEY as string)
   : (null as any)

--- a/netlify/functions/send-email-test.ts
+++ b/netlify/functions/send-email-test.ts
@@ -1,6 +1,7 @@
 import type {Handler} from '@netlify/functions'
 import {createClient} from '@sanity/client'
 import {Resend} from 'resend'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 import {renderCampaignHtml, htmlToText} from '../lib/email/renderCampaign'
 
 const sanity = createClient({
@@ -14,7 +15,7 @@ const sanity = createClient({
   useCdn: false,
 })
 
-const resendApiKey = process.env.RESEND_API_KEY
+const resendApiKey = resolveResendApiKey()
 const resend = resendApiKey ? new Resend(resendApiKey) : null
 
 const handler: Handler = async (event) => {

--- a/netlify/functions/send-vendor-invite.ts
+++ b/netlify/functions/send-vendor-invite.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto'
 import {createClient} from '@sanity/client'
 import {Resend} from 'resend'
 import {triggerOnboardingCampaign} from '../lib/vendorOnboardingCampaign'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 
 const JSON_HEADERS = {
   'Content-Type': 'application/json',
@@ -20,7 +21,7 @@ const TOKEN =
   process.env.SANITY_ACCESS_TOKEN ||
   ''
 
-const resendApiKey = process.env.RESEND_API_KEY || ''
+const resendApiKey = resolveResendApiKey() || ''
 const resendFrom =
   process.env.RESEND_FROM ||
   process.env.EMAIL_FROM ||

--- a/netlify/functions/sendAbandonedCartEmails.tsx
+++ b/netlify/functions/sendAbandonedCartEmails.tsx
@@ -4,6 +4,7 @@ import {render} from '@react-email/render'
 import {Resend} from 'resend'
 import {logFunctionExecution} from '../../utils/functionLogger'
 import AbandonedCartEmail, {CartItem as EmailCartItem} from '../emails/AbandonedCartEmail'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 
 type CheckoutSessionDoc = {
   _id: string
@@ -38,7 +39,7 @@ const sanity =
       })
     : null
 
-const resendApiKey = process.env.RESEND_API_KEY || ''
+const resendApiKey = resolveResendApiKey() || ''
 const resendClient = resendApiKey ? new Resend(resendApiKey) : null
 const FROM_EMAIL =
   process.env.FROM_EMAIL ||

--- a/netlify/functions/sendCustomerEmail.ts
+++ b/netlify/functions/sendCustomerEmail.ts
@@ -1,5 +1,6 @@
 import type {Handler} from '@netlify/functions'
 import {Resend} from 'resend'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -7,7 +8,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'Content-Type',
 }
 
-const resendApiKey = process.env.RESEND_API_KEY
+const resendApiKey = resolveResendApiKey()
 const fromAddress =
   process.env.RESEND_FROM || 'F.A.S. Motorsports <noreply@updates.fasmotorsports.com>'
 const resend = resendApiKey ? new Resend(resendApiKey) : null

--- a/netlify/functions/sendQuoteEmail.ts
+++ b/netlify/functions/sendQuoteEmail.ts
@@ -1,9 +1,10 @@
 import {Resend} from 'resend'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 import {createClient} from '@sanity/client'
 import type {Handler} from '@netlify/functions'
 import {PDFDocument, StandardFonts, rgb} from 'pdf-lib'
 
-const resend = new Resend(process.env.RESEND_API_KEY)
+const resend = new Resend(resolveResendApiKey()!)
 
 // Prefer the single write token you set up; no fallback to PUBLIC_*
 const sanity = createClient({

--- a/netlify/functions/sendVendorEmail.ts
+++ b/netlify/functions/sendVendorEmail.ts
@@ -1,5 +1,6 @@
 import type {Handler} from '@netlify/functions'
 import {Resend} from 'resend'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 import {buildVendorEmail, type VendorEmailTemplateInput} from '../lib/emailTemplates/vendorEmails'
 
 const corsHeaders = {
@@ -8,7 +9,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'Content-Type',
 }
 
-const resendApiKey = process.env.RESEND_API_KEY
+const resendApiKey = resolveResendApiKey()
 const resend = resendApiKey ? new Resend(resendApiKey) : null
 
 const handler: Handler = async (event) => {

--- a/netlify/functions/stripeWebhook.ts
+++ b/netlify/functions/stripeWebhook.ts
@@ -52,6 +52,7 @@ import {
   markAbandonedCheckoutRecovered,
 } from '../lib/abandonedCheckouts'
 import {resolveStripeSecretKey, STRIPE_SECRET_ENV_KEYS} from '../lib/stripeEnv'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 
 function cleanCartItemForStorage(item: CartItem): CartItem {
   const normalizeAddOnLabel = (value: string): string | undefined => {
@@ -2356,7 +2357,7 @@ if (!stripeKey) {
   )
 }
 const stripe = stripeKey ? new Stripe(stripeKey) : (null as any)
-const RESEND_API_KEY = process.env.RESEND_API_KEY || ''
+const RESEND_API_KEY = resolveResendApiKey() || ''
 const resendClient = RESEND_API_KEY ? new Resend(RESEND_API_KEY) : null
 const RESEND_ABANDONED_AUDIENCE =
   process.env.RESEND_AUDIENCE_ABANDONED_CART || process.env.RESEND_AUDIENCE_ABANDONED_CART_ID || ''

--- a/netlify/functions/vendor-application.ts
+++ b/netlify/functions/vendor-application.ts
@@ -1,6 +1,7 @@
 import type {Handler} from '@netlify/functions'
 import {createClient} from '@sanity/client'
 import {Resend} from 'resend'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 
 const sanityClient = createClient({
   projectId: process.env.SANITY_PROJECT_ID || 'r4og35qd',
@@ -10,7 +11,7 @@ const sanityClient = createClient({
   useCdn: false,
 })
 
-const resend = new Resend(process.env.RESEND_API_KEY!)
+const resend = new Resend(resolveResendApiKey()!)
 
 export const handler: Handler = async (event) => {
   const headers = {

--- a/netlify/functions/welcome-subscriber.ts
+++ b/netlify/functions/welcome-subscriber.ts
@@ -3,6 +3,7 @@ import {createClient} from '@sanity/client'
 import {Resend} from 'resend'
 import {syncContact} from '../lib/resend/contacts'
 import {computeCustomerName, splitFullName} from '../../shared/customerName'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 
 const sanityClient = createClient({
   projectId: process.env.SANITY_PROJECT_ID || 'r4og35qd',
@@ -12,7 +13,7 @@ const sanityClient = createClient({
   useCdn: false,
 })
 
-const resend = new Resend(process.env.RESEND_API_KEY!)
+const resend = new Resend(resolveResendApiKey()!)
 
 export const handler: Handler = async (event) => {
   const headers = {

--- a/netlify/lib/resend/contacts.ts
+++ b/netlify/lib/resend/contacts.ts
@@ -1,4 +1,5 @@
 import {Resend} from 'resend'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 
 type ContactAction = 'created' | 'updated' | 'removed' | 'skipped' | 'failed'
 
@@ -20,7 +21,7 @@ export interface SyncContactResult {
   subscribers: ContactAudienceResult
 }
 
-const resendApiKey = process.env.RESEND_API_KEY
+const resendApiKey = resolveResendApiKey()
 const resend = resendApiKey ? new Resend(resendApiKey) : null
 
 const AUDIENCE_GENERAL =

--- a/netlify/lib/vendorOnboardingCampaign.ts
+++ b/netlify/lib/vendorOnboardingCampaign.ts
@@ -1,5 +1,6 @@
 import {createClient} from '@sanity/client'
 import {Resend} from 'resend'
+import {resolveResendApiKey} from '../../shared/resendEnv'
 
 const projectId = process.env.SANITY_STUDIO_PROJECT_ID || process.env.SANITY_PROJECT_ID
 const dataset = process.env.SANITY_STUDIO_DATASET || process.env.SANITY_DATASET
@@ -9,7 +10,7 @@ const token =
   process.env.SANITY_ACCESS_TOKEN ||
   ''
 const apiVersion = process.env.SANITY_API_VERSION || '2024-10-01'
-const resendApiKey = process.env.RESEND_API_KEY || ''
+const resendApiKey = resolveResendApiKey() || ''
 const SITE_URL =
   process.env.SANITY_STUDIO_SITE_URL ||
   process.env.PUBLIC_SITE_URL ||

--- a/packages/sanity-config/src/desk/deskStructure.ts
+++ b/packages/sanity-config/src/desk/deskStructure.ts
@@ -112,6 +112,10 @@ const documentTablePane = (S: any, id: string, title: string, component: Compone
         .id(`${id}-table`),
     ])
 
+// Wrapper to ensure the campaign performance view always receives a valid component function
+const EmailCampaignPerformanceView: ComponentType = (props: any) =>
+  React.createElement(CampaignPerformance as any, props)
+
 const CustomersAllTableView: ComponentType = () =>
   React.createElement(CustomersDocumentTable as any, {
     title: 'All Customers',
@@ -1232,9 +1236,7 @@ const createMarketingSection = (S: any) =>
                             .documentId(documentId)
                             .views([
                               S.view.form().title('Editor'),
-                              S.view
-                                .component(CampaignPerformance as ComponentType)
-                                .title('Performance'),
+                              S.view.component(EmailCampaignPerformanceView).title('Performance'),
                             ]),
                         ),
                     ),

--- a/packages/sanity-config/src/utils/emailService.ts
+++ b/packages/sanity-config/src/utils/emailService.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto'
 import {createClient} from '@sanity/client'
 import {Resend} from 'resend'
+import {resolveResendApiKey} from '../../../shared/resendEnv'
 
 export type EmailProvider = 'sendgrid' | 'mailgun' | 'ses' | 'postmark' | 'resend'
 
@@ -37,7 +38,8 @@ type EmailEventUpdate = {
 
 const SUPPORTED_PROVIDERS: EmailProvider[] = ['sendgrid', 'mailgun', 'ses', 'postmark', 'resend']
 const providerEnv = (process.env.EMAIL_PROVIDER || '').toLowerCase()
-const hasResendKey = Boolean(process.env.RESEND_API_KEY)
+const RESEND_API_KEY = resolveResendApiKey()
+const hasResendKey = Boolean(RESEND_API_KEY)
 const EMAIL_PROVIDER: EmailProvider =
   (SUPPORTED_PROVIDERS.includes(providerEnv as EmailProvider)
     ? (providerEnv as EmailProvider)
@@ -48,7 +50,7 @@ const DEFAULT_FROM =
 const SANITY_PROJECT_ID = process.env.SANITY_STUDIO_PROJECT_ID
 const SANITY_DATASET = process.env.SANITY_STUDIO_DATASET
 const SANITY_TOKEN = process.env.SANITY_API_TOKEN
-const RESEND_CLIENT = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null
+const RESEND_CLIENT = RESEND_API_KEY ? new Resend(RESEND_API_KEY) : null
 
 const emailLogClient =
   SANITY_PROJECT_ID && SANITY_DATASET && SANITY_TOKEN

--- a/shared/resendEnv.ts
+++ b/shared/resendEnv.ts
@@ -1,0 +1,13 @@
+export function resolveResendApiKey(): string | undefined {
+  return (
+    process.env.RESEND_API_KEY ||
+    process.env.RESEND_KEY ||
+    process.env.RESEND_SECRET ||
+    process.env.RESEND_TOKEN ||
+    process.env.RESEND_SECRET_KEY
+  )?.trim() || undefined
+}
+
+export function hasResendApiKey(): boolean {
+  return Boolean(resolveResendApiKey())
+}


### PR DESCRIPTION
## Summary
- add a shared helper to resolve the Resend API key from multiple environment variable names
- update transactional email functions and supporting libraries to use the shared Resend configuration
- ensure marketing and automation utilities instantiate Resend clients consistently

## Testing
- pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694119aab4cc832c9dd45392f314d3d4)