### PR TITLE
Fix Sanity asset ref property identifiers

### DIFF
--- a/packages/sanity-config/src/utils/ensureProductMeta.ts
+++ b/packages/sanity-config/src/utils/ensureProductMeta.ts
@@ -133,12 +133,12 @@ type ProductForMeta = {
   slug?: {current?: string}
   shortDescription?: PortableTextBlock[] | string
   description?: PortableTextBlock[] | string
-  images?: Array<{asset?: {\_ref?: string}; alt?: unknown}>
+  images?: Array<{asset?: {_ref?: string}; alt?: unknown}>
   metaTitle?: string
   metaDescription?: string
   focusKeyword?: string
   canonicalUrl?: string
-  socialImage?: {asset?: {\_ref?: string}}
+  socialImage?: {asset?: {_ref?: string}}
   analytics?: Record<string, unknown>
   merchantCenterStatus?: Record<string, unknown>
   gtin?: string


### PR DESCRIPTION
## Summary
- update product meta typing to use valid `_ref` identifiers for asset references
- align social image asset reference with valid syntax

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69428c2eae48832ca8a7df08e2a98ef8)