### PR TITLE
fix: resolve Netlify build SchemaError and missing schema types

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Sanity Studio",
+      "runtimeExecutable": "/Users/ambermin/LocalStorm/Workspace/DevProjects/GitHub/fas-sanity/node_modules/.bin/sanity",
+      "runtimeArgs": ["dev"],
+      "port": 3333
+    },
+    {
+      "name": "Netlify Functions (via CLI)",
+      "runtimeExecutable": "/Users/ambermin/LocalStorm/Workspace/DevProjects/GitHub/fas-sanity/node_modules/.bin/netlify",
+      "runtimeArgs": ["functions:serve", "--functions", "netlify/functions", "--port", "8888"],
+      "port": 8888
+    },
+    {
+      "name": "Local Functions Server (no CLI)",
+      "runtimeExecutable": "/Users/ambermin/LocalStorm/Workspace/DevProjects/GitHub/fas-sanity/node_modules/.bin/tsx",
+      "runtimeArgs": ["scripts/local-functions-server.ts"],
+      "port": 8888
+    }
+  ]
+}

--- a/packages/sanity-config/sanity.config.ts
+++ b/packages/sanity-config/sanity.config.ts
@@ -24,7 +24,7 @@ import {media} from 'sanity-plugin-media'
 import {cloudinaryAssetSourcePlugin} from 'sanity-plugin-cloudinary'
 import {assist} from '@sanity/assist'
 // Removed presentation/preview tool
-import schemaTypes from './src/schemaTypes/index'
+import {schemaTypes} from './src/schemaTypes/index'
 import {deskStructure} from './src/desk/deskStructure'
 import {deskStructureBuilderTool} from './src/plugins/deskStructureBuilder'
 import resolveDocumentActions from './src/resolveDocumentActions'

--- a/packages/sanity-config/src/schemaTypes/documents/service.ts
+++ b/packages/sanity-config/src/schemaTypes/documents/service.ts
@@ -1,0 +1,72 @@
+import {defineField, defineType} from 'sanity'
+
+const SERVICE_CATEGORY_OPTIONS = [
+  {title: 'Engine', value: 'engine'},
+  {title: 'Transmission', value: 'transmission'},
+  {title: 'Suspension', value: 'suspension'},
+  {title: 'Brakes', value: 'brakes'},
+  {title: 'Electrical', value: 'electrical'},
+  {title: 'Exhaust', value: 'exhaust'},
+  {title: 'Tuning', value: 'tuning'},
+  {title: 'Tires & Wheels', value: 'tires_wheels'},
+  {title: 'Detailing', value: 'detailing'},
+  {title: 'Fabrication', value: 'fabrication'},
+  {title: 'Diagnostic', value: 'diagnostic'},
+  {title: 'Other', value: 'other'},
+]
+
+export default defineType({
+  name: 'service',
+  title: 'Services',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Service Name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'category',
+      title: 'Category',
+      type: 'string',
+      options: {list: SERVICE_CATEGORY_OPTIONS},
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+      rows: 3,
+    }),
+    defineField({
+      name: 'estimatedDuration',
+      title: 'Estimated Duration (hours)',
+      type: 'number',
+    }),
+    defineField({
+      name: 'basePrice',
+      title: 'Base Price',
+      type: 'number',
+      description: 'Starting price in USD',
+    }),
+    defineField({
+      name: 'active',
+      title: 'Active',
+      type: 'boolean',
+      initialValue: true,
+    }),
+  ],
+  preview: {
+    select: {
+      name: 'name',
+      category: 'category',
+      active: 'active',
+    },
+    prepare({name, category, active}) {
+      return {
+        title: name || 'Service',
+        subtitle: [category, active === false ? '(inactive)' : undefined].filter(Boolean).join(' · '),
+      }
+    },
+  },
+})

--- a/packages/sanity-config/src/schemaTypes/documents/shipment.ts
+++ b/packages/sanity-config/src/schemaTypes/documents/shipment.ts
@@ -56,11 +56,11 @@ export default defineType({
       ],
     }),
     defineField({
-      name: 'order',
-      title: 'Order',
-      type: 'reference',
-      weak: true,
-      to: [{type: 'order'}],
+      name: 'medusaOrderId',
+      title: 'Medusa Order ID',
+      type: 'string',
+      description: 'Read-only reference to the Medusa order. Commerce authority lives in Medusa.',
+      readOnly: true,
     }),
     defineField({
       name: 'invoice',

--- a/packages/sanity-config/src/schemaTypes/documents/vehicle.ts
+++ b/packages/sanity-config/src/schemaTypes/documents/vehicle.ts
@@ -1,0 +1,70 @@
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
+  name: 'vehicle',
+  title: 'Vehicles',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'year',
+      title: 'Year',
+      type: 'number',
+    }),
+    defineField({
+      name: 'make',
+      title: 'Make',
+      type: 'string',
+    }),
+    defineField({
+      name: 'model',
+      title: 'Model',
+      type: 'string',
+    }),
+    defineField({
+      name: 'trim',
+      title: 'Trim',
+      type: 'string',
+    }),
+    defineField({
+      name: 'vin',
+      title: 'VIN',
+      type: 'string',
+    }),
+    defineField({
+      name: 'color',
+      title: 'Color',
+      type: 'string',
+    }),
+    defineField({
+      name: 'mileage',
+      title: 'Mileage',
+      type: 'number',
+    }),
+    defineField({
+      name: 'owner',
+      title: 'Owner',
+      type: 'reference',
+      to: [{type: 'customer'}],
+    }),
+    defineField({
+      name: 'notes',
+      title: 'Notes',
+      type: 'text',
+      rows: 3,
+    }),
+  ],
+  preview: {
+    select: {
+      year: 'year',
+      make: 'make',
+      model: 'model',
+      vin: 'vin',
+    },
+    prepare({year, make, model, vin}) {
+      return {
+        title: [year, make, model].filter(Boolean).join(' ') || 'Vehicle',
+        subtitle: vin ? `VIN: ${vin}` : undefined,
+      }
+    },
+  },
+})

--- a/packages/sanity-config/src/schemaTypes/index.ts
+++ b/packages/sanity-config/src/schemaTypes/index.ts
@@ -131,6 +131,8 @@ import vendorMessage from './documents/vendorMessage'
 import vendorProductSubmission from './documents/vendorProductSubmission'
 import expense from './documents/expense'
 import appointment from './documents/appointment'
+import vehicle from './documents/vehicle'
+import service from './documents/service'
 import workOrder from './documents/workOrder'
 import inventoryRecord from './documents/inventoryRecord'
 import manufacturingOrder from './documents/manufacturingOrder'
@@ -257,6 +259,8 @@ const documents = [
   vendorProductSubmission,
   expense,
   appointment,
+  vehicle,
+  service,
   workOrder,
   inventoryRecord,
   manufacturingOrder,


### PR DESCRIPTION
## Summary

- **Build fix**: Switch `schemaTypes` import in `sanity.config.ts` from default to named export — eliminates CJS/ESM interop edge case that caused `SchemaError: schema.types is undefined` during Netlify build
- **Schema fix**: Add `vehicle` and `service` document schemas that `appointment` references but were never registered
- **Arch fix**: Replace `shipment.order` reference (type `order` doesn't belong in Sanity) with a `readOnly` string `medusaOrderId` — orders are Medusa's domain per architecture law
- **Dev tooling**: Add `.claude/launch.json` with worktree-compatible dev server configs (uses absolute paths to main repo binaries since worktrees share `node_modules`)

## Test plan

- [x] Netlify deploy succeeds (no `SchemaError` on `pnpm run build:ci`)
- [ ] Sanity Studio loads without schema errors in the browser
- [ ] `appointment` document editor renders vehicle and service reference fields
- [ ] `shipment` document editor shows `medusaOrderId` as a read-only string field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Sanity schemas (adds new document types and renames `shipment.order` to `medusaOrderId`), which can affect existing content, queries, and migrations, though changes are localized to Studio/schema config.
> 
> **Overview**
> Fixes a Netlify/Sanity build issue by switching `sanity.config.ts` to import `schemaTypes` via the named export, avoiding an ESM/CJS interop edge case that produced `SchemaError: schema.types is undefined`.
> 
> Registers previously missing `vehicle` and `service` document schemas (needed by `appointment` references) and updates the `shipment` schema to remove the Sanity `order` reference in favor of a read-only `medusaOrderId` string.
> 
> Adds `.claude/launch.json` with local debug configurations for Sanity Studio and Netlify/local functions servers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78e18748e6899156948387b35d4fff906c9a2885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->